### PR TITLE
Fix Bug with Dividing by Zero

### DIFF
--- a/MagicGradients/LinearGradient.cs
+++ b/MagicGradients/LinearGradient.cs
@@ -44,7 +44,7 @@ namespace MagicGradients
             var angleRad = GradientMath.ToRadians(Angle);
             var computedLength = Math.Sqrt(Math.Pow(width * Math.Cos(angleRad), 2) + Math.Pow(height * Math.Sin(angleRad), 2));
 
-            return (float)(offset / computedLength);
+            return computedLength != 0 ? (float)(offset / computedLength) : 1;
         }
 
         public override void Render(RenderContext context)


### PR DESCRIPTION
This is a copy of changes from the previous PR, because, after squash commit, I was required to cherry-pick changes into the rebased branch.

I checked all available Gradients in Playground & Playground Lite and they work fine after changes