### PR TITLE
Fix Xamarin.Forms 4.8 crash: background property already exists

### DIFF
--- a/MagicGradients/MagicGradients.csproj
+++ b/MagicGradients/MagicGradients.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <Authors>Marcin Gierlasiński, Bohdan Benetskyi and Contributors</Authors>
     <Product>Magic Gradients</Product>
     <Description>Draw breathtaking backgrounds in your Xamarin.Forms application. It's a kind of magic. Powered by SkiaSharp.</Description>

--- a/MagicGradients/StyleSheets.cs
+++ b/MagicGradients/StyleSheets.cs
@@ -2,8 +2,8 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Text;
 using Xamarin.Forms.StyleSheets;
+using Registrar = Xamarin.Forms.Internals.Registrar;
 
 namespace MagicGradients
 {
@@ -11,25 +11,36 @@ namespace MagicGradients
     {
         public static void RegisterStyle(string name, Type targetType, string bindablePropertyName)
         {
-            var stylePropertyInfo = typeof(Xamarin.Forms.Internals.Registrar).GetProperty("StyleProperties",
-                BindingFlags.Static | BindingFlags.NonPublic);
-            if (stylePropertyInfo == null)
+            var stylePropertyInfo = typeof(Registrar).GetProperty("StyleProperties", BindingFlags.Static | BindingFlags.NonPublic);
+            var styleProperties = stylePropertyInfo?.GetValue(null);
+
+            if (styleProperties == null)
                 return;
 
-            var styleProperties = stylePropertyInfo.GetValue(null);
-
+            var stylePropertiesType = styleProperties.GetType();
             var styleAttributeType = typeof(StyleSheet).Assembly.GetType("Xamarin.Forms.StyleSheets.StylePropertyAttribute");
             var styleAttributeInstance = Activator.CreateInstance(styleAttributeType, name, targetType, bindablePropertyName);
 
-            var dictionaryAdd = styleProperties.GetType().GetMethod("Add");
-            if (dictionaryAdd == null)
+            var containsKeyMethod = stylePropertiesType.GetMethod("ContainsKey");
+            if (containsKeyMethod == null)
                 return;
 
-            var styleListType = typeof(List<>).MakeGenericType(styleAttributeType);
-            var styleList = (IList)Activator.CreateInstance(styleListType);
+            var containsKey = (bool)containsKeyMethod.Invoke(styleProperties, new object[] { name });
+            if (containsKey)
+            {
+                var itemProperty = stylePropertiesType.GetProperty("Item");
+                var attributes = itemProperty?.GetValue(styleProperties, new object[] { name });
 
-            styleList.Add(styleAttributeInstance);
-            dictionaryAdd.Invoke(styleProperties, new object[] { name, styleList });
+                attributes?.GetType().GetMethod("Add")?.Invoke(attributes, new[] { styleAttributeInstance });
+            }
+            else
+            {
+                var styleListType = typeof(List<>).MakeGenericType(styleAttributeType);
+                var styleList = (IList)Activator.CreateInstance(styleListType);
+                styleList.Add(styleAttributeInstance);
+
+                stylePropertiesType.GetMethod("Add")?.Invoke(styleProperties, new object[] { name, styleList });
+            }
         }
     }
 }

--- a/Playground/Playground.Android/Playground.Android.csproj
+++ b/Playground/Playground.Android/Playground.Android.csproj
@@ -52,7 +52,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.6.0.800" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1269" />
     <PackageReference Include="Xamarin.Android.Support.ViewPager" Version="28.0.0.3" />
     <PackageReference Include="Xamarin.Android.Support.Design" Version="28.0.0.3" />
     <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="28.0.0.3" />

--- a/Playground/Playground.Android/Resources/Resource.designer.cs
+++ b/Playground/Playground.Android/Resources/Resource.designer.cs
@@ -368,6 +368,7 @@ namespace Playground.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.collapsedTitleGravity = global::Playground.Droid.Resource.Attribute.collapsedTitleGravity;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.collapsedTitleTextAppearance = global::Playground.Droid.Resource.Attribute.collapsedTitleTextAppearance;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.collapseIcon = global::Playground.Droid.Resource.Attribute.collapseIcon;
+			global::Xamarin.Forms.Platform.Android.Resource.Attribute.collectionViewStyle = global::Playground.Droid.Resource.Attribute.collectionViewStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.color = global::Playground.Droid.Resource.Attribute.color;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.colorAccent = global::Playground.Droid.Resource.Attribute.colorAccent;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.colorBackgroundFloating = global::Playground.Droid.Resource.Attribute.colorBackgroundFloating;
@@ -1510,6 +1511,7 @@ namespace Playground.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.String.fab_transformation_sheet_behavior = global::Playground.Droid.Resource.String.fab_transformation_sheet_behavior;
 			global::Xamarin.Forms.Platform.Android.Resource.String.hide_bottom_view_on_scroll_behavior = global::Playground.Droid.Resource.String.hide_bottom_view_on_scroll_behavior;
 			global::Xamarin.Forms.Platform.Android.Resource.String.mtrl_chip_close_icon_content_description = global::Playground.Droid.Resource.String.mtrl_chip_close_icon_content_description;
+			global::Xamarin.Forms.Platform.Android.Resource.String.overflow_tab_title = global::Playground.Droid.Resource.String.overflow_tab_title;
 			global::Xamarin.Forms.Platform.Android.Resource.String.password_toggle_content_description = global::Playground.Droid.Resource.String.password_toggle_content_description;
 			global::Xamarin.Forms.Platform.Android.Resource.String.path_password_eye = global::Playground.Droid.Resource.String.path_password_eye;
 			global::Xamarin.Forms.Platform.Android.Resource.String.path_password_eye_mask_strike_through = global::Playground.Droid.Resource.String.path_password_eye_mask_strike_through;
@@ -1715,7 +1717,8 @@ namespace Playground.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Style.CardView = global::Playground.Droid.Resource.Style.CardView;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.CardView_Dark = global::Playground.Droid.Resource.Style.CardView_Dark;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.CardView_Light = global::Playground.Droid.Resource.Style.CardView_Light;
-			global::Xamarin.Forms.Platform.Android.Resource.Style.collectionViewStyle = global::Playground.Droid.Resource.Style.collectionViewStyle;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.collectionViewScrollBars = global::Playground.Droid.Resource.Style.collectionViewScrollBars;
+			global::Xamarin.Forms.Platform.Android.Resource.Style.collectionViewTheme = global::Playground.Droid.Resource.Style.collectionViewTheme;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.MainTheme = global::Playground.Droid.Resource.Style.MainTheme;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.MainTheme_Base = global::Playground.Droid.Resource.Style.MainTheme_Base;
 			global::Xamarin.Forms.Platform.Android.Resource.Style.Platform_AppCompat = global::Playground.Droid.Resource.Style.Platform_AppCompat;
@@ -2446,6 +2449,8 @@ namespace Playground.Droid
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColor_android_startY = global::Playground.Droid.Resource.Styleable.GradientColor_android_startY;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColor_android_tileMode = global::Playground.Droid.Resource.Styleable.GradientColor_android_tileMode;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.GradientColor_android_type = global::Playground.Droid.Resource.Styleable.GradientColor_android_type;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ItemsViewRendererTheme = global::Playground.Droid.Resource.Styleable.ItemsViewRendererTheme;
+			global::Xamarin.Forms.Platform.Android.Resource.Styleable.ItemsViewRendererTheme_collectionViewStyle = global::Playground.Droid.Resource.Styleable.ItemsViewRendererTheme_collectionViewStyle;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.LinearLayoutCompat = global::Playground.Droid.Resource.Styleable.LinearLayoutCompat;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.LinearLayoutCompat_android_baselineAligned = global::Playground.Droid.Resource.Styleable.LinearLayoutCompat_android_baselineAligned;
 			global::Xamarin.Forms.Platform.Android.Resource.Styleable.LinearLayoutCompat_android_baselineAlignedChildIndex = global::Playground.Droid.Resource.Styleable.LinearLayoutCompat_android_baselineAlignedChildIndex;
@@ -2933,6 +2938,7 @@ namespace Playground.Droid
 			global::Xamarin.Forms.Platform.Resource.Attribute.collapsedTitleGravity = global::Playground.Droid.Resource.Attribute.collapsedTitleGravity;
 			global::Xamarin.Forms.Platform.Resource.Attribute.collapsedTitleTextAppearance = global::Playground.Droid.Resource.Attribute.collapsedTitleTextAppearance;
 			global::Xamarin.Forms.Platform.Resource.Attribute.collapseIcon = global::Playground.Droid.Resource.Attribute.collapseIcon;
+			global::Xamarin.Forms.Platform.Resource.Attribute.collectionViewStyle = global::Playground.Droid.Resource.Attribute.collectionViewStyle;
 			global::Xamarin.Forms.Platform.Resource.Attribute.color = global::Playground.Droid.Resource.Attribute.color;
 			global::Xamarin.Forms.Platform.Resource.Attribute.colorAccent = global::Playground.Droid.Resource.Attribute.colorAccent;
 			global::Xamarin.Forms.Platform.Resource.Attribute.colorBackgroundFloating = global::Playground.Droid.Resource.Attribute.colorBackgroundFloating;
@@ -4075,6 +4081,7 @@ namespace Playground.Droid
 			global::Xamarin.Forms.Platform.Resource.String.fab_transformation_sheet_behavior = global::Playground.Droid.Resource.String.fab_transformation_sheet_behavior;
 			global::Xamarin.Forms.Platform.Resource.String.hide_bottom_view_on_scroll_behavior = global::Playground.Droid.Resource.String.hide_bottom_view_on_scroll_behavior;
 			global::Xamarin.Forms.Platform.Resource.String.mtrl_chip_close_icon_content_description = global::Playground.Droid.Resource.String.mtrl_chip_close_icon_content_description;
+			global::Xamarin.Forms.Platform.Resource.String.overflow_tab_title = global::Playground.Droid.Resource.String.overflow_tab_title;
 			global::Xamarin.Forms.Platform.Resource.String.password_toggle_content_description = global::Playground.Droid.Resource.String.password_toggle_content_description;
 			global::Xamarin.Forms.Platform.Resource.String.path_password_eye = global::Playground.Droid.Resource.String.path_password_eye;
 			global::Xamarin.Forms.Platform.Resource.String.path_password_eye_mask_strike_through = global::Playground.Droid.Resource.String.path_password_eye_mask_strike_through;
@@ -4280,7 +4287,8 @@ namespace Playground.Droid
 			global::Xamarin.Forms.Platform.Resource.Style.CardView = global::Playground.Droid.Resource.Style.CardView;
 			global::Xamarin.Forms.Platform.Resource.Style.CardView_Dark = global::Playground.Droid.Resource.Style.CardView_Dark;
 			global::Xamarin.Forms.Platform.Resource.Style.CardView_Light = global::Playground.Droid.Resource.Style.CardView_Light;
-			global::Xamarin.Forms.Platform.Resource.Style.collectionViewStyle = global::Playground.Droid.Resource.Style.collectionViewStyle;
+			global::Xamarin.Forms.Platform.Resource.Style.collectionViewScrollBars = global::Playground.Droid.Resource.Style.collectionViewScrollBars;
+			global::Xamarin.Forms.Platform.Resource.Style.collectionViewTheme = global::Playground.Droid.Resource.Style.collectionViewTheme;
 			global::Xamarin.Forms.Platform.Resource.Style.MainTheme = global::Playground.Droid.Resource.Style.MainTheme;
 			global::Xamarin.Forms.Platform.Resource.Style.MainTheme_Base = global::Playground.Droid.Resource.Style.MainTheme_Base;
 			global::Xamarin.Forms.Platform.Resource.Style.Platform_AppCompat = global::Playground.Droid.Resource.Style.Platform_AppCompat;
@@ -5011,6 +5019,8 @@ namespace Playground.Droid
 			global::Xamarin.Forms.Platform.Resource.Styleable.GradientColor_android_startY = global::Playground.Droid.Resource.Styleable.GradientColor_android_startY;
 			global::Xamarin.Forms.Platform.Resource.Styleable.GradientColor_android_tileMode = global::Playground.Droid.Resource.Styleable.GradientColor_android_tileMode;
 			global::Xamarin.Forms.Platform.Resource.Styleable.GradientColor_android_type = global::Playground.Droid.Resource.Styleable.GradientColor_android_type;
+			global::Xamarin.Forms.Platform.Resource.Styleable.ItemsViewRendererTheme = global::Playground.Droid.Resource.Styleable.ItemsViewRendererTheme;
+			global::Xamarin.Forms.Platform.Resource.Styleable.ItemsViewRendererTheme_collectionViewStyle = global::Playground.Droid.Resource.Styleable.ItemsViewRendererTheme_collectionViewStyle;
 			global::Xamarin.Forms.Platform.Resource.Styleable.LinearLayoutCompat = global::Playground.Droid.Resource.Styleable.LinearLayoutCompat;
 			global::Xamarin.Forms.Platform.Resource.Styleable.LinearLayoutCompat_android_baselineAligned = global::Playground.Droid.Resource.Styleable.LinearLayoutCompat_android_baselineAligned;
 			global::Xamarin.Forms.Platform.Resource.Styleable.LinearLayoutCompat_android_baselineAlignedChildIndex = global::Playground.Droid.Resource.Styleable.LinearLayoutCompat_android_baselineAlignedChildIndex;
@@ -5852,1084 +5862,1087 @@ namespace Playground.Droid
 			public const int collapseIcon = 2130903168;
 			
 			// aapt resource value: 0x7F030083
-			public const int color = 2130903171;
+			public const int collectionViewStyle = 2130903171;
 			
 			// aapt resource value: 0x7F030084
-			public const int colorAccent = 2130903172;
+			public const int color = 2130903172;
 			
 			// aapt resource value: 0x7F030085
-			public const int colorBackgroundFloating = 2130903173;
+			public const int colorAccent = 2130903173;
 			
 			// aapt resource value: 0x7F030086
-			public const int colorButtonNormal = 2130903174;
+			public const int colorBackgroundFloating = 2130903174;
 			
 			// aapt resource value: 0x7F030087
-			public const int colorControlActivated = 2130903175;
+			public const int colorButtonNormal = 2130903175;
 			
 			// aapt resource value: 0x7F030088
-			public const int colorControlHighlight = 2130903176;
+			public const int colorControlActivated = 2130903176;
 			
 			// aapt resource value: 0x7F030089
-			public const int colorControlNormal = 2130903177;
+			public const int colorControlHighlight = 2130903177;
 			
 			// aapt resource value: 0x7F03008A
-			public const int colorError = 2130903178;
+			public const int colorControlNormal = 2130903178;
 			
 			// aapt resource value: 0x7F03008B
-			public const int colorPrimary = 2130903179;
+			public const int colorError = 2130903179;
 			
 			// aapt resource value: 0x7F03008C
-			public const int colorPrimaryDark = 2130903180;
+			public const int colorPrimary = 2130903180;
 			
 			// aapt resource value: 0x7F03008D
-			public const int colorSecondary = 2130903181;
+			public const int colorPrimaryDark = 2130903181;
 			
 			// aapt resource value: 0x7F03008E
-			public const int colorSwitchThumbNormal = 2130903182;
+			public const int colorSecondary = 2130903182;
 			
 			// aapt resource value: 0x7F03008F
-			public const int commitIcon = 2130903183;
+			public const int colorSwitchThumbNormal = 2130903183;
 			
 			// aapt resource value: 0x7F030090
-			public const int contentDescription = 2130903184;
+			public const int commitIcon = 2130903184;
 			
 			// aapt resource value: 0x7F030091
-			public const int contentInsetEnd = 2130903185;
+			public const int contentDescription = 2130903185;
 			
 			// aapt resource value: 0x7F030092
-			public const int contentInsetEndWithActions = 2130903186;
+			public const int contentInsetEnd = 2130903186;
 			
 			// aapt resource value: 0x7F030093
-			public const int contentInsetLeft = 2130903187;
+			public const int contentInsetEndWithActions = 2130903187;
 			
 			// aapt resource value: 0x7F030094
-			public const int contentInsetRight = 2130903188;
+			public const int contentInsetLeft = 2130903188;
 			
 			// aapt resource value: 0x7F030095
-			public const int contentInsetStart = 2130903189;
+			public const int contentInsetRight = 2130903189;
 			
 			// aapt resource value: 0x7F030096
-			public const int contentInsetStartWithNavigation = 2130903190;
+			public const int contentInsetStart = 2130903190;
 			
 			// aapt resource value: 0x7F030097
-			public const int contentPadding = 2130903191;
+			public const int contentInsetStartWithNavigation = 2130903191;
 			
 			// aapt resource value: 0x7F030098
-			public const int contentPaddingBottom = 2130903192;
+			public const int contentPadding = 2130903192;
 			
 			// aapt resource value: 0x7F030099
-			public const int contentPaddingLeft = 2130903193;
+			public const int contentPaddingBottom = 2130903193;
 			
 			// aapt resource value: 0x7F03009A
-			public const int contentPaddingRight = 2130903194;
+			public const int contentPaddingLeft = 2130903194;
 			
 			// aapt resource value: 0x7F03009B
-			public const int contentPaddingTop = 2130903195;
+			public const int contentPaddingRight = 2130903195;
 			
 			// aapt resource value: 0x7F03009C
-			public const int contentScrim = 2130903196;
+			public const int contentPaddingTop = 2130903196;
 			
 			// aapt resource value: 0x7F03009D
-			public const int controlBackground = 2130903197;
+			public const int contentScrim = 2130903197;
 			
 			// aapt resource value: 0x7F03009E
-			public const int coordinatorLayoutStyle = 2130903198;
+			public const int controlBackground = 2130903198;
 			
 			// aapt resource value: 0x7F03009F
-			public const int cornerRadius = 2130903199;
+			public const int coordinatorLayoutStyle = 2130903199;
 			
 			// aapt resource value: 0x7F0300A0
-			public const int counterEnabled = 2130903200;
+			public const int cornerRadius = 2130903200;
 			
 			// aapt resource value: 0x7F0300A1
-			public const int counterMaxLength = 2130903201;
+			public const int counterEnabled = 2130903201;
 			
 			// aapt resource value: 0x7F0300A2
-			public const int counterOverflowTextAppearance = 2130903202;
+			public const int counterMaxLength = 2130903202;
 			
 			// aapt resource value: 0x7F0300A3
-			public const int counterTextAppearance = 2130903203;
+			public const int counterOverflowTextAppearance = 2130903203;
 			
 			// aapt resource value: 0x7F0300A4
-			public const int customNavigationLayout = 2130903204;
+			public const int counterTextAppearance = 2130903204;
 			
 			// aapt resource value: 0x7F0300A5
-			public const int defaultQueryHint = 2130903205;
+			public const int customNavigationLayout = 2130903205;
 			
 			// aapt resource value: 0x7F0300A6
-			public const int dialogCornerRadius = 2130903206;
+			public const int defaultQueryHint = 2130903206;
 			
 			// aapt resource value: 0x7F0300A7
-			public const int dialogPreferredPadding = 2130903207;
+			public const int dialogCornerRadius = 2130903207;
 			
 			// aapt resource value: 0x7F0300A8
-			public const int dialogTheme = 2130903208;
+			public const int dialogPreferredPadding = 2130903208;
 			
 			// aapt resource value: 0x7F0300A9
-			public const int displayOptions = 2130903209;
+			public const int dialogTheme = 2130903209;
 			
 			// aapt resource value: 0x7F0300AA
-			public const int divider = 2130903210;
+			public const int displayOptions = 2130903210;
 			
 			// aapt resource value: 0x7F0300AB
-			public const int dividerHorizontal = 2130903211;
+			public const int divider = 2130903211;
 			
 			// aapt resource value: 0x7F0300AC
-			public const int dividerPadding = 2130903212;
+			public const int dividerHorizontal = 2130903212;
 			
 			// aapt resource value: 0x7F0300AD
-			public const int dividerVertical = 2130903213;
+			public const int dividerPadding = 2130903213;
 			
 			// aapt resource value: 0x7F0300AE
-			public const int drawableSize = 2130903214;
+			public const int dividerVertical = 2130903214;
 			
 			// aapt resource value: 0x7F0300AF
-			public const int drawerArrowStyle = 2130903215;
-			
-			// aapt resource value: 0x7F0300B1
-			public const int dropdownListPreferredItemHeight = 2130903217;
+			public const int drawableSize = 2130903215;
 			
 			// aapt resource value: 0x7F0300B0
-			public const int dropDownListViewStyle = 2130903216;
+			public const int drawerArrowStyle = 2130903216;
 			
 			// aapt resource value: 0x7F0300B2
-			public const int editTextBackground = 2130903218;
+			public const int dropdownListPreferredItemHeight = 2130903218;
+			
+			// aapt resource value: 0x7F0300B1
+			public const int dropDownListViewStyle = 2130903217;
 			
 			// aapt resource value: 0x7F0300B3
-			public const int editTextColor = 2130903219;
+			public const int editTextBackground = 2130903219;
 			
 			// aapt resource value: 0x7F0300B4
-			public const int editTextStyle = 2130903220;
+			public const int editTextColor = 2130903220;
 			
 			// aapt resource value: 0x7F0300B5
-			public const int elevation = 2130903221;
+			public const int editTextStyle = 2130903221;
 			
 			// aapt resource value: 0x7F0300B6
-			public const int enforceMaterialTheme = 2130903222;
+			public const int elevation = 2130903222;
 			
 			// aapt resource value: 0x7F0300B7
-			public const int enforceTextAppearance = 2130903223;
+			public const int enforceMaterialTheme = 2130903223;
 			
 			// aapt resource value: 0x7F0300B8
-			public const int errorEnabled = 2130903224;
+			public const int enforceTextAppearance = 2130903224;
 			
 			// aapt resource value: 0x7F0300B9
-			public const int errorTextAppearance = 2130903225;
+			public const int errorEnabled = 2130903225;
 			
 			// aapt resource value: 0x7F0300BA
-			public const int expandActivityOverflowButtonDrawable = 2130903226;
+			public const int errorTextAppearance = 2130903226;
 			
 			// aapt resource value: 0x7F0300BB
-			public const int expanded = 2130903227;
+			public const int expandActivityOverflowButtonDrawable = 2130903227;
 			
 			// aapt resource value: 0x7F0300BC
-			public const int expandedTitleGravity = 2130903228;
+			public const int expanded = 2130903228;
 			
 			// aapt resource value: 0x7F0300BD
-			public const int expandedTitleMargin = 2130903229;
+			public const int expandedTitleGravity = 2130903229;
 			
 			// aapt resource value: 0x7F0300BE
-			public const int expandedTitleMarginBottom = 2130903230;
+			public const int expandedTitleMargin = 2130903230;
 			
 			// aapt resource value: 0x7F0300BF
-			public const int expandedTitleMarginEnd = 2130903231;
+			public const int expandedTitleMarginBottom = 2130903231;
 			
 			// aapt resource value: 0x7F0300C0
-			public const int expandedTitleMarginStart = 2130903232;
+			public const int expandedTitleMarginEnd = 2130903232;
 			
 			// aapt resource value: 0x7F0300C1
-			public const int expandedTitleMarginTop = 2130903233;
+			public const int expandedTitleMarginStart = 2130903233;
 			
 			// aapt resource value: 0x7F0300C2
-			public const int expandedTitleTextAppearance = 2130903234;
+			public const int expandedTitleMarginTop = 2130903234;
 			
 			// aapt resource value: 0x7F0300C3
-			public const int externalRouteEnabledDrawable = 2130903235;
+			public const int expandedTitleTextAppearance = 2130903235;
 			
 			// aapt resource value: 0x7F0300C4
-			public const int fabAlignmentMode = 2130903236;
+			public const int externalRouteEnabledDrawable = 2130903236;
 			
 			// aapt resource value: 0x7F0300C5
-			public const int fabCradleMargin = 2130903237;
+			public const int fabAlignmentMode = 2130903237;
 			
 			// aapt resource value: 0x7F0300C6
-			public const int fabCradleRoundedCornerRadius = 2130903238;
+			public const int fabCradleMargin = 2130903238;
 			
 			// aapt resource value: 0x7F0300C7
-			public const int fabCradleVerticalOffset = 2130903239;
+			public const int fabCradleRoundedCornerRadius = 2130903239;
 			
 			// aapt resource value: 0x7F0300C8
-			public const int fabCustomSize = 2130903240;
+			public const int fabCradleVerticalOffset = 2130903240;
 			
 			// aapt resource value: 0x7F0300C9
-			public const int fabSize = 2130903241;
+			public const int fabCustomSize = 2130903241;
 			
 			// aapt resource value: 0x7F0300CA
-			public const int fastScrollEnabled = 2130903242;
+			public const int fabSize = 2130903242;
 			
 			// aapt resource value: 0x7F0300CB
-			public const int fastScrollHorizontalThumbDrawable = 2130903243;
+			public const int fastScrollEnabled = 2130903243;
 			
 			// aapt resource value: 0x7F0300CC
-			public const int fastScrollHorizontalTrackDrawable = 2130903244;
+			public const int fastScrollHorizontalThumbDrawable = 2130903244;
 			
 			// aapt resource value: 0x7F0300CD
-			public const int fastScrollVerticalThumbDrawable = 2130903245;
+			public const int fastScrollHorizontalTrackDrawable = 2130903245;
 			
 			// aapt resource value: 0x7F0300CE
-			public const int fastScrollVerticalTrackDrawable = 2130903246;
+			public const int fastScrollVerticalThumbDrawable = 2130903246;
 			
 			// aapt resource value: 0x7F0300CF
-			public const int firstBaselineToTopHeight = 2130903247;
+			public const int fastScrollVerticalTrackDrawable = 2130903247;
 			
 			// aapt resource value: 0x7F0300D0
-			public const int floatingActionButtonStyle = 2130903248;
+			public const int firstBaselineToTopHeight = 2130903248;
 			
 			// aapt resource value: 0x7F0300D1
-			public const int font = 2130903249;
+			public const int floatingActionButtonStyle = 2130903249;
 			
 			// aapt resource value: 0x7F0300D2
-			public const int fontFamily = 2130903250;
+			public const int font = 2130903250;
 			
 			// aapt resource value: 0x7F0300D3
-			public const int fontProviderAuthority = 2130903251;
+			public const int fontFamily = 2130903251;
 			
 			// aapt resource value: 0x7F0300D4
-			public const int fontProviderCerts = 2130903252;
+			public const int fontProviderAuthority = 2130903252;
 			
 			// aapt resource value: 0x7F0300D5
-			public const int fontProviderFetchStrategy = 2130903253;
+			public const int fontProviderCerts = 2130903253;
 			
 			// aapt resource value: 0x7F0300D6
-			public const int fontProviderFetchTimeout = 2130903254;
+			public const int fontProviderFetchStrategy = 2130903254;
 			
 			// aapt resource value: 0x7F0300D7
-			public const int fontProviderPackage = 2130903255;
+			public const int fontProviderFetchTimeout = 2130903255;
 			
 			// aapt resource value: 0x7F0300D8
-			public const int fontProviderQuery = 2130903256;
+			public const int fontProviderPackage = 2130903256;
 			
 			// aapt resource value: 0x7F0300D9
-			public const int fontStyle = 2130903257;
+			public const int fontProviderQuery = 2130903257;
 			
 			// aapt resource value: 0x7F0300DA
-			public const int fontVariationSettings = 2130903258;
+			public const int fontStyle = 2130903258;
 			
 			// aapt resource value: 0x7F0300DB
-			public const int fontWeight = 2130903259;
+			public const int fontVariationSettings = 2130903259;
 			
 			// aapt resource value: 0x7F0300DC
-			public const int foregroundInsidePadding = 2130903260;
+			public const int fontWeight = 2130903260;
 			
 			// aapt resource value: 0x7F0300DD
-			public const int gapBetweenBars = 2130903261;
+			public const int foregroundInsidePadding = 2130903261;
 			
 			// aapt resource value: 0x7F0300DE
-			public const int goIcon = 2130903262;
+			public const int gapBetweenBars = 2130903262;
 			
 			// aapt resource value: 0x7F0300DF
-			public const int headerLayout = 2130903263;
+			public const int goIcon = 2130903263;
 			
 			// aapt resource value: 0x7F0300E0
-			public const int height = 2130903264;
+			public const int headerLayout = 2130903264;
 			
 			// aapt resource value: 0x7F0300E1
-			public const int helperText = 2130903265;
+			public const int height = 2130903265;
 			
 			// aapt resource value: 0x7F0300E2
-			public const int helperTextEnabled = 2130903266;
+			public const int helperText = 2130903266;
 			
 			// aapt resource value: 0x7F0300E3
-			public const int helperTextTextAppearance = 2130903267;
+			public const int helperTextEnabled = 2130903267;
 			
 			// aapt resource value: 0x7F0300E4
-			public const int hideMotionSpec = 2130903268;
+			public const int helperTextTextAppearance = 2130903268;
 			
 			// aapt resource value: 0x7F0300E5
-			public const int hideOnContentScroll = 2130903269;
+			public const int hideMotionSpec = 2130903269;
 			
 			// aapt resource value: 0x7F0300E6
-			public const int hideOnScroll = 2130903270;
+			public const int hideOnContentScroll = 2130903270;
 			
 			// aapt resource value: 0x7F0300E7
-			public const int hintAnimationEnabled = 2130903271;
+			public const int hideOnScroll = 2130903271;
 			
 			// aapt resource value: 0x7F0300E8
-			public const int hintEnabled = 2130903272;
+			public const int hintAnimationEnabled = 2130903272;
 			
 			// aapt resource value: 0x7F0300E9
-			public const int hintTextAppearance = 2130903273;
+			public const int hintEnabled = 2130903273;
 			
 			// aapt resource value: 0x7F0300EA
-			public const int homeAsUpIndicator = 2130903274;
+			public const int hintTextAppearance = 2130903274;
 			
 			// aapt resource value: 0x7F0300EB
-			public const int homeLayout = 2130903275;
+			public const int homeAsUpIndicator = 2130903275;
 			
 			// aapt resource value: 0x7F0300EC
-			public const int hoveredFocusedTranslationZ = 2130903276;
+			public const int homeLayout = 2130903276;
 			
 			// aapt resource value: 0x7F0300ED
-			public const int icon = 2130903277;
+			public const int hoveredFocusedTranslationZ = 2130903277;
 			
 			// aapt resource value: 0x7F0300EE
-			public const int iconEndPadding = 2130903278;
+			public const int icon = 2130903278;
 			
 			// aapt resource value: 0x7F0300EF
-			public const int iconGravity = 2130903279;
-			
-			// aapt resource value: 0x7F0300F5
-			public const int iconifiedByDefault = 2130903285;
+			public const int iconEndPadding = 2130903279;
 			
 			// aapt resource value: 0x7F0300F0
-			public const int iconPadding = 2130903280;
-			
-			// aapt resource value: 0x7F0300F1
-			public const int iconSize = 2130903281;
-			
-			// aapt resource value: 0x7F0300F2
-			public const int iconStartPadding = 2130903282;
-			
-			// aapt resource value: 0x7F0300F3
-			public const int iconTint = 2130903283;
-			
-			// aapt resource value: 0x7F0300F4
-			public const int iconTintMode = 2130903284;
+			public const int iconGravity = 2130903280;
 			
 			// aapt resource value: 0x7F0300F6
-			public const int imageButtonStyle = 2130903286;
+			public const int iconifiedByDefault = 2130903286;
+			
+			// aapt resource value: 0x7F0300F1
+			public const int iconPadding = 2130903281;
+			
+			// aapt resource value: 0x7F0300F2
+			public const int iconSize = 2130903282;
+			
+			// aapt resource value: 0x7F0300F3
+			public const int iconStartPadding = 2130903283;
+			
+			// aapt resource value: 0x7F0300F4
+			public const int iconTint = 2130903284;
+			
+			// aapt resource value: 0x7F0300F5
+			public const int iconTintMode = 2130903285;
 			
 			// aapt resource value: 0x7F0300F7
-			public const int indeterminateProgressStyle = 2130903287;
+			public const int imageButtonStyle = 2130903287;
 			
 			// aapt resource value: 0x7F0300F8
-			public const int initialActivityCount = 2130903288;
+			public const int indeterminateProgressStyle = 2130903288;
 			
 			// aapt resource value: 0x7F0300F9
-			public const int insetForeground = 2130903289;
+			public const int initialActivityCount = 2130903289;
 			
 			// aapt resource value: 0x7F0300FA
-			public const int isLightTheme = 2130903290;
+			public const int insetForeground = 2130903290;
 			
 			// aapt resource value: 0x7F0300FB
-			public const int itemBackground = 2130903291;
+			public const int isLightTheme = 2130903291;
 			
 			// aapt resource value: 0x7F0300FC
-			public const int itemHorizontalPadding = 2130903292;
+			public const int itemBackground = 2130903292;
 			
 			// aapt resource value: 0x7F0300FD
-			public const int itemHorizontalTranslationEnabled = 2130903293;
+			public const int itemHorizontalPadding = 2130903293;
 			
 			// aapt resource value: 0x7F0300FE
-			public const int itemIconPadding = 2130903294;
+			public const int itemHorizontalTranslationEnabled = 2130903294;
 			
 			// aapt resource value: 0x7F0300FF
-			public const int itemIconSize = 2130903295;
+			public const int itemIconPadding = 2130903295;
 			
 			// aapt resource value: 0x7F030100
-			public const int itemIconTint = 2130903296;
+			public const int itemIconSize = 2130903296;
 			
 			// aapt resource value: 0x7F030101
-			public const int itemPadding = 2130903297;
+			public const int itemIconTint = 2130903297;
 			
 			// aapt resource value: 0x7F030102
-			public const int itemSpacing = 2130903298;
+			public const int itemPadding = 2130903298;
 			
 			// aapt resource value: 0x7F030103
-			public const int itemTextAppearance = 2130903299;
+			public const int itemSpacing = 2130903299;
 			
 			// aapt resource value: 0x7F030104
-			public const int itemTextAppearanceActive = 2130903300;
+			public const int itemTextAppearance = 2130903300;
 			
 			// aapt resource value: 0x7F030105
-			public const int itemTextAppearanceInactive = 2130903301;
+			public const int itemTextAppearanceActive = 2130903301;
 			
 			// aapt resource value: 0x7F030106
-			public const int itemTextColor = 2130903302;
+			public const int itemTextAppearanceInactive = 2130903302;
 			
 			// aapt resource value: 0x7F030107
-			public const int keylines = 2130903303;
+			public const int itemTextColor = 2130903303;
 			
 			// aapt resource value: 0x7F030108
-			public const int labelVisibilityMode = 2130903304;
+			public const int keylines = 2130903304;
 			
 			// aapt resource value: 0x7F030109
-			public const int lastBaselineToBottomHeight = 2130903305;
+			public const int labelVisibilityMode = 2130903305;
 			
 			// aapt resource value: 0x7F03010A
-			public const int layout = 2130903306;
+			public const int lastBaselineToBottomHeight = 2130903306;
 			
 			// aapt resource value: 0x7F03010B
-			public const int layoutManager = 2130903307;
+			public const int layout = 2130903307;
 			
 			// aapt resource value: 0x7F03010C
-			public const int layout_anchor = 2130903308;
+			public const int layoutManager = 2130903308;
 			
 			// aapt resource value: 0x7F03010D
-			public const int layout_anchorGravity = 2130903309;
+			public const int layout_anchor = 2130903309;
 			
 			// aapt resource value: 0x7F03010E
-			public const int layout_behavior = 2130903310;
+			public const int layout_anchorGravity = 2130903310;
 			
 			// aapt resource value: 0x7F03010F
-			public const int layout_collapseMode = 2130903311;
+			public const int layout_behavior = 2130903311;
 			
 			// aapt resource value: 0x7F030110
-			public const int layout_collapseParallaxMultiplier = 2130903312;
+			public const int layout_collapseMode = 2130903312;
 			
 			// aapt resource value: 0x7F030111
-			public const int layout_dodgeInsetEdges = 2130903313;
+			public const int layout_collapseParallaxMultiplier = 2130903313;
 			
 			// aapt resource value: 0x7F030112
-			public const int layout_insetEdge = 2130903314;
+			public const int layout_dodgeInsetEdges = 2130903314;
 			
 			// aapt resource value: 0x7F030113
-			public const int layout_keyline = 2130903315;
+			public const int layout_insetEdge = 2130903315;
 			
 			// aapt resource value: 0x7F030114
-			public const int layout_scrollFlags = 2130903316;
+			public const int layout_keyline = 2130903316;
 			
 			// aapt resource value: 0x7F030115
-			public const int layout_scrollInterpolator = 2130903317;
+			public const int layout_scrollFlags = 2130903317;
 			
 			// aapt resource value: 0x7F030116
-			public const int liftOnScroll = 2130903318;
+			public const int layout_scrollInterpolator = 2130903318;
 			
 			// aapt resource value: 0x7F030117
-			public const int lineHeight = 2130903319;
+			public const int liftOnScroll = 2130903319;
 			
 			// aapt resource value: 0x7F030118
-			public const int lineSpacing = 2130903320;
+			public const int lineHeight = 2130903320;
 			
 			// aapt resource value: 0x7F030119
-			public const int listChoiceBackgroundIndicator = 2130903321;
+			public const int lineSpacing = 2130903321;
 			
 			// aapt resource value: 0x7F03011A
-			public const int listDividerAlertDialog = 2130903322;
+			public const int listChoiceBackgroundIndicator = 2130903322;
 			
 			// aapt resource value: 0x7F03011B
-			public const int listItemLayout = 2130903323;
+			public const int listDividerAlertDialog = 2130903323;
 			
 			// aapt resource value: 0x7F03011C
-			public const int listLayout = 2130903324;
+			public const int listItemLayout = 2130903324;
 			
 			// aapt resource value: 0x7F03011D
-			public const int listMenuViewStyle = 2130903325;
+			public const int listLayout = 2130903325;
 			
 			// aapt resource value: 0x7F03011E
-			public const int listPopupWindowStyle = 2130903326;
+			public const int listMenuViewStyle = 2130903326;
 			
 			// aapt resource value: 0x7F03011F
-			public const int listPreferredItemHeight = 2130903327;
+			public const int listPopupWindowStyle = 2130903327;
 			
 			// aapt resource value: 0x7F030120
-			public const int listPreferredItemHeightLarge = 2130903328;
+			public const int listPreferredItemHeight = 2130903328;
 			
 			// aapt resource value: 0x7F030121
-			public const int listPreferredItemHeightSmall = 2130903329;
+			public const int listPreferredItemHeightLarge = 2130903329;
 			
 			// aapt resource value: 0x7F030122
-			public const int listPreferredItemPaddingLeft = 2130903330;
+			public const int listPreferredItemHeightSmall = 2130903330;
 			
 			// aapt resource value: 0x7F030123
-			public const int listPreferredItemPaddingRight = 2130903331;
+			public const int listPreferredItemPaddingLeft = 2130903331;
 			
 			// aapt resource value: 0x7F030124
-			public const int logo = 2130903332;
+			public const int listPreferredItemPaddingRight = 2130903332;
 			
 			// aapt resource value: 0x7F030125
-			public const int logoDescription = 2130903333;
+			public const int logo = 2130903333;
 			
 			// aapt resource value: 0x7F030126
-			public const int materialButtonStyle = 2130903334;
+			public const int logoDescription = 2130903334;
 			
 			// aapt resource value: 0x7F030127
-			public const int materialCardViewStyle = 2130903335;
+			public const int materialButtonStyle = 2130903335;
 			
 			// aapt resource value: 0x7F030128
-			public const int maxActionInlineWidth = 2130903336;
+			public const int materialCardViewStyle = 2130903336;
 			
 			// aapt resource value: 0x7F030129
-			public const int maxButtonHeight = 2130903337;
+			public const int maxActionInlineWidth = 2130903337;
 			
 			// aapt resource value: 0x7F03012A
-			public const int maxImageSize = 2130903338;
+			public const int maxButtonHeight = 2130903338;
 			
 			// aapt resource value: 0x7F03012B
-			public const int measureWithLargestChild = 2130903339;
+			public const int maxImageSize = 2130903339;
 			
 			// aapt resource value: 0x7F03012C
-			public const int mediaRouteAudioTrackDrawable = 2130903340;
+			public const int measureWithLargestChild = 2130903340;
 			
 			// aapt resource value: 0x7F03012D
-			public const int mediaRouteButtonStyle = 2130903341;
+			public const int mediaRouteAudioTrackDrawable = 2130903341;
 			
 			// aapt resource value: 0x7F03012E
-			public const int mediaRouteButtonTint = 2130903342;
+			public const int mediaRouteButtonStyle = 2130903342;
 			
 			// aapt resource value: 0x7F03012F
-			public const int mediaRouteCloseDrawable = 2130903343;
+			public const int mediaRouteButtonTint = 2130903343;
 			
 			// aapt resource value: 0x7F030130
-			public const int mediaRouteControlPanelThemeOverlay = 2130903344;
+			public const int mediaRouteCloseDrawable = 2130903344;
 			
 			// aapt resource value: 0x7F030131
-			public const int mediaRouteDefaultIconDrawable = 2130903345;
+			public const int mediaRouteControlPanelThemeOverlay = 2130903345;
 			
 			// aapt resource value: 0x7F030132
-			public const int mediaRoutePauseDrawable = 2130903346;
+			public const int mediaRouteDefaultIconDrawable = 2130903346;
 			
 			// aapt resource value: 0x7F030133
-			public const int mediaRoutePlayDrawable = 2130903347;
+			public const int mediaRoutePauseDrawable = 2130903347;
 			
 			// aapt resource value: 0x7F030134
-			public const int mediaRouteSpeakerGroupIconDrawable = 2130903348;
+			public const int mediaRoutePlayDrawable = 2130903348;
 			
 			// aapt resource value: 0x7F030135
-			public const int mediaRouteSpeakerIconDrawable = 2130903349;
+			public const int mediaRouteSpeakerGroupIconDrawable = 2130903349;
 			
 			// aapt resource value: 0x7F030136
-			public const int mediaRouteStopDrawable = 2130903350;
+			public const int mediaRouteSpeakerIconDrawable = 2130903350;
 			
 			// aapt resource value: 0x7F030137
-			public const int mediaRouteTheme = 2130903351;
+			public const int mediaRouteStopDrawable = 2130903351;
 			
 			// aapt resource value: 0x7F030138
-			public const int mediaRouteTvIconDrawable = 2130903352;
+			public const int mediaRouteTheme = 2130903352;
 			
 			// aapt resource value: 0x7F030139
-			public const int menu = 2130903353;
+			public const int mediaRouteTvIconDrawable = 2130903353;
 			
 			// aapt resource value: 0x7F03013A
-			public const int multiChoiceItemLayout = 2130903354;
+			public const int menu = 2130903354;
 			
 			// aapt resource value: 0x7F03013B
-			public const int navigationContentDescription = 2130903355;
+			public const int multiChoiceItemLayout = 2130903355;
 			
 			// aapt resource value: 0x7F03013C
-			public const int navigationIcon = 2130903356;
+			public const int navigationContentDescription = 2130903356;
 			
 			// aapt resource value: 0x7F03013D
-			public const int navigationMode = 2130903357;
+			public const int navigationIcon = 2130903357;
 			
 			// aapt resource value: 0x7F03013E
-			public const int navigationViewStyle = 2130903358;
+			public const int navigationMode = 2130903358;
 			
 			// aapt resource value: 0x7F03013F
-			public const int numericModifiers = 2130903359;
+			public const int navigationViewStyle = 2130903359;
 			
 			// aapt resource value: 0x7F030140
-			public const int overlapAnchor = 2130903360;
+			public const int numericModifiers = 2130903360;
 			
 			// aapt resource value: 0x7F030141
-			public const int paddingBottomNoButtons = 2130903361;
+			public const int overlapAnchor = 2130903361;
 			
 			// aapt resource value: 0x7F030142
-			public const int paddingEnd = 2130903362;
+			public const int paddingBottomNoButtons = 2130903362;
 			
 			// aapt resource value: 0x7F030143
-			public const int paddingStart = 2130903363;
+			public const int paddingEnd = 2130903363;
 			
 			// aapt resource value: 0x7F030144
-			public const int paddingTopNoTitle = 2130903364;
+			public const int paddingStart = 2130903364;
 			
 			// aapt resource value: 0x7F030145
-			public const int panelBackground = 2130903365;
+			public const int paddingTopNoTitle = 2130903365;
 			
 			// aapt resource value: 0x7F030146
-			public const int panelMenuListTheme = 2130903366;
+			public const int panelBackground = 2130903366;
 			
 			// aapt resource value: 0x7F030147
-			public const int panelMenuListWidth = 2130903367;
+			public const int panelMenuListTheme = 2130903367;
 			
 			// aapt resource value: 0x7F030148
-			public const int passwordToggleContentDescription = 2130903368;
+			public const int panelMenuListWidth = 2130903368;
 			
 			// aapt resource value: 0x7F030149
-			public const int passwordToggleDrawable = 2130903369;
+			public const int passwordToggleContentDescription = 2130903369;
 			
 			// aapt resource value: 0x7F03014A
-			public const int passwordToggleEnabled = 2130903370;
+			public const int passwordToggleDrawable = 2130903370;
 			
 			// aapt resource value: 0x7F03014B
-			public const int passwordToggleTint = 2130903371;
+			public const int passwordToggleEnabled = 2130903371;
 			
 			// aapt resource value: 0x7F03014C
-			public const int passwordToggleTintMode = 2130903372;
+			public const int passwordToggleTint = 2130903372;
 			
 			// aapt resource value: 0x7F03014D
-			public const int popupMenuStyle = 2130903373;
+			public const int passwordToggleTintMode = 2130903373;
 			
 			// aapt resource value: 0x7F03014E
-			public const int popupTheme = 2130903374;
+			public const int popupMenuStyle = 2130903374;
 			
 			// aapt resource value: 0x7F03014F
-			public const int popupWindowStyle = 2130903375;
+			public const int popupTheme = 2130903375;
 			
 			// aapt resource value: 0x7F030150
-			public const int preserveIconSpacing = 2130903376;
+			public const int popupWindowStyle = 2130903376;
 			
 			// aapt resource value: 0x7F030151
-			public const int pressedTranslationZ = 2130903377;
+			public const int preserveIconSpacing = 2130903377;
 			
 			// aapt resource value: 0x7F030152
-			public const int progressBarPadding = 2130903378;
+			public const int pressedTranslationZ = 2130903378;
 			
 			// aapt resource value: 0x7F030153
-			public const int progressBarStyle = 2130903379;
+			public const int progressBarPadding = 2130903379;
 			
 			// aapt resource value: 0x7F030154
-			public const int queryBackground = 2130903380;
+			public const int progressBarStyle = 2130903380;
 			
 			// aapt resource value: 0x7F030155
-			public const int queryHint = 2130903381;
+			public const int queryBackground = 2130903381;
 			
 			// aapt resource value: 0x7F030156
-			public const int radioButtonStyle = 2130903382;
+			public const int queryHint = 2130903382;
 			
 			// aapt resource value: 0x7F030157
-			public const int ratingBarStyle = 2130903383;
+			public const int radioButtonStyle = 2130903383;
 			
 			// aapt resource value: 0x7F030158
-			public const int ratingBarStyleIndicator = 2130903384;
+			public const int ratingBarStyle = 2130903384;
 			
 			// aapt resource value: 0x7F030159
-			public const int ratingBarStyleSmall = 2130903385;
+			public const int ratingBarStyleIndicator = 2130903385;
 			
 			// aapt resource value: 0x7F03015A
-			public const int reverseLayout = 2130903386;
+			public const int ratingBarStyleSmall = 2130903386;
 			
 			// aapt resource value: 0x7F03015B
-			public const int rippleColor = 2130903387;
+			public const int reverseLayout = 2130903387;
 			
 			// aapt resource value: 0x7F03015C
-			public const int scrimAnimationDuration = 2130903388;
+			public const int rippleColor = 2130903388;
 			
 			// aapt resource value: 0x7F03015D
-			public const int scrimBackground = 2130903389;
+			public const int scrimAnimationDuration = 2130903389;
 			
 			// aapt resource value: 0x7F03015E
-			public const int scrimVisibleHeightTrigger = 2130903390;
+			public const int scrimBackground = 2130903390;
 			
 			// aapt resource value: 0x7F03015F
-			public const int searchHintIcon = 2130903391;
+			public const int scrimVisibleHeightTrigger = 2130903391;
 			
 			// aapt resource value: 0x7F030160
-			public const int searchIcon = 2130903392;
+			public const int searchHintIcon = 2130903392;
 			
 			// aapt resource value: 0x7F030161
-			public const int searchViewStyle = 2130903393;
+			public const int searchIcon = 2130903393;
 			
 			// aapt resource value: 0x7F030162
-			public const int seekBarStyle = 2130903394;
+			public const int searchViewStyle = 2130903394;
 			
 			// aapt resource value: 0x7F030163
-			public const int selectableItemBackground = 2130903395;
+			public const int seekBarStyle = 2130903395;
 			
 			// aapt resource value: 0x7F030164
-			public const int selectableItemBackgroundBorderless = 2130903396;
+			public const int selectableItemBackground = 2130903396;
 			
 			// aapt resource value: 0x7F030165
-			public const int showAsAction = 2130903397;
+			public const int selectableItemBackgroundBorderless = 2130903397;
 			
 			// aapt resource value: 0x7F030166
-			public const int showDividers = 2130903398;
+			public const int showAsAction = 2130903398;
 			
 			// aapt resource value: 0x7F030167
-			public const int showMotionSpec = 2130903399;
+			public const int showDividers = 2130903399;
 			
 			// aapt resource value: 0x7F030168
-			public const int showText = 2130903400;
+			public const int showMotionSpec = 2130903400;
 			
 			// aapt resource value: 0x7F030169
-			public const int showTitle = 2130903401;
+			public const int showText = 2130903401;
 			
 			// aapt resource value: 0x7F03016A
-			public const int singleChoiceItemLayout = 2130903402;
+			public const int showTitle = 2130903402;
 			
 			// aapt resource value: 0x7F03016B
-			public const int singleLine = 2130903403;
+			public const int singleChoiceItemLayout = 2130903403;
 			
 			// aapt resource value: 0x7F03016C
-			public const int singleSelection = 2130903404;
+			public const int singleLine = 2130903404;
 			
 			// aapt resource value: 0x7F03016D
-			public const int snackbarButtonStyle = 2130903405;
+			public const int singleSelection = 2130903405;
 			
 			// aapt resource value: 0x7F03016E
-			public const int snackbarStyle = 2130903406;
+			public const int snackbarButtonStyle = 2130903406;
 			
 			// aapt resource value: 0x7F03016F
-			public const int spanCount = 2130903407;
+			public const int snackbarStyle = 2130903407;
 			
 			// aapt resource value: 0x7F030170
-			public const int spinBars = 2130903408;
+			public const int spanCount = 2130903408;
 			
 			// aapt resource value: 0x7F030171
-			public const int spinnerDropDownItemStyle = 2130903409;
+			public const int spinBars = 2130903409;
 			
 			// aapt resource value: 0x7F030172
-			public const int spinnerStyle = 2130903410;
+			public const int spinnerDropDownItemStyle = 2130903410;
 			
 			// aapt resource value: 0x7F030173
-			public const int splitTrack = 2130903411;
+			public const int spinnerStyle = 2130903411;
 			
 			// aapt resource value: 0x7F030174
-			public const int srcCompat = 2130903412;
+			public const int splitTrack = 2130903412;
 			
 			// aapt resource value: 0x7F030175
-			public const int stackFromEnd = 2130903413;
+			public const int srcCompat = 2130903413;
 			
 			// aapt resource value: 0x7F030176
-			public const int state_above_anchor = 2130903414;
+			public const int stackFromEnd = 2130903414;
 			
 			// aapt resource value: 0x7F030177
-			public const int state_collapsed = 2130903415;
+			public const int state_above_anchor = 2130903415;
 			
 			// aapt resource value: 0x7F030178
-			public const int state_collapsible = 2130903416;
+			public const int state_collapsed = 2130903416;
 			
 			// aapt resource value: 0x7F030179
-			public const int state_liftable = 2130903417;
+			public const int state_collapsible = 2130903417;
 			
 			// aapt resource value: 0x7F03017A
-			public const int state_lifted = 2130903418;
+			public const int state_liftable = 2130903418;
 			
 			// aapt resource value: 0x7F03017B
-			public const int statusBarBackground = 2130903419;
+			public const int state_lifted = 2130903419;
 			
 			// aapt resource value: 0x7F03017C
-			public const int statusBarScrim = 2130903420;
+			public const int statusBarBackground = 2130903420;
 			
 			// aapt resource value: 0x7F03017D
-			public const int strokeColor = 2130903421;
+			public const int statusBarScrim = 2130903421;
 			
 			// aapt resource value: 0x7F03017E
-			public const int strokeWidth = 2130903422;
+			public const int strokeColor = 2130903422;
 			
 			// aapt resource value: 0x7F03017F
-			public const int subMenuArrow = 2130903423;
+			public const int strokeWidth = 2130903423;
 			
 			// aapt resource value: 0x7F030180
-			public const int submitBackground = 2130903424;
+			public const int subMenuArrow = 2130903424;
 			
 			// aapt resource value: 0x7F030181
-			public const int subtitle = 2130903425;
+			public const int submitBackground = 2130903425;
 			
 			// aapt resource value: 0x7F030182
-			public const int subtitleTextAppearance = 2130903426;
+			public const int subtitle = 2130903426;
 			
 			// aapt resource value: 0x7F030183
-			public const int subtitleTextColor = 2130903427;
+			public const int subtitleTextAppearance = 2130903427;
 			
 			// aapt resource value: 0x7F030184
-			public const int subtitleTextStyle = 2130903428;
+			public const int subtitleTextColor = 2130903428;
 			
 			// aapt resource value: 0x7F030185
-			public const int suggestionRowLayout = 2130903429;
+			public const int subtitleTextStyle = 2130903429;
 			
 			// aapt resource value: 0x7F030186
-			public const int switchMinWidth = 2130903430;
+			public const int suggestionRowLayout = 2130903430;
 			
 			// aapt resource value: 0x7F030187
-			public const int switchPadding = 2130903431;
+			public const int switchMinWidth = 2130903431;
 			
 			// aapt resource value: 0x7F030188
-			public const int switchStyle = 2130903432;
+			public const int switchPadding = 2130903432;
 			
 			// aapt resource value: 0x7F030189
-			public const int switchTextAppearance = 2130903433;
+			public const int switchStyle = 2130903433;
 			
 			// aapt resource value: 0x7F03018A
-			public const int tabBackground = 2130903434;
+			public const int switchTextAppearance = 2130903434;
 			
 			// aapt resource value: 0x7F03018B
-			public const int tabContentStart = 2130903435;
+			public const int tabBackground = 2130903435;
 			
 			// aapt resource value: 0x7F03018C
-			public const int tabGravity = 2130903436;
+			public const int tabContentStart = 2130903436;
 			
 			// aapt resource value: 0x7F03018D
-			public const int tabIconTint = 2130903437;
+			public const int tabGravity = 2130903437;
 			
 			// aapt resource value: 0x7F03018E
-			public const int tabIconTintMode = 2130903438;
+			public const int tabIconTint = 2130903438;
 			
 			// aapt resource value: 0x7F03018F
-			public const int tabIndicator = 2130903439;
+			public const int tabIconTintMode = 2130903439;
 			
 			// aapt resource value: 0x7F030190
-			public const int tabIndicatorAnimationDuration = 2130903440;
+			public const int tabIndicator = 2130903440;
 			
 			// aapt resource value: 0x7F030191
-			public const int tabIndicatorColor = 2130903441;
+			public const int tabIndicatorAnimationDuration = 2130903441;
 			
 			// aapt resource value: 0x7F030192
-			public const int tabIndicatorFullWidth = 2130903442;
+			public const int tabIndicatorColor = 2130903442;
 			
 			// aapt resource value: 0x7F030193
-			public const int tabIndicatorGravity = 2130903443;
+			public const int tabIndicatorFullWidth = 2130903443;
 			
 			// aapt resource value: 0x7F030194
-			public const int tabIndicatorHeight = 2130903444;
+			public const int tabIndicatorGravity = 2130903444;
 			
 			// aapt resource value: 0x7F030195
-			public const int tabInlineLabel = 2130903445;
+			public const int tabIndicatorHeight = 2130903445;
 			
 			// aapt resource value: 0x7F030196
-			public const int tabMaxWidth = 2130903446;
+			public const int tabInlineLabel = 2130903446;
 			
 			// aapt resource value: 0x7F030197
-			public const int tabMinWidth = 2130903447;
+			public const int tabMaxWidth = 2130903447;
 			
 			// aapt resource value: 0x7F030198
-			public const int tabMode = 2130903448;
+			public const int tabMinWidth = 2130903448;
 			
 			// aapt resource value: 0x7F030199
-			public const int tabPadding = 2130903449;
+			public const int tabMode = 2130903449;
 			
 			// aapt resource value: 0x7F03019A
-			public const int tabPaddingBottom = 2130903450;
+			public const int tabPadding = 2130903450;
 			
 			// aapt resource value: 0x7F03019B
-			public const int tabPaddingEnd = 2130903451;
+			public const int tabPaddingBottom = 2130903451;
 			
 			// aapt resource value: 0x7F03019C
-			public const int tabPaddingStart = 2130903452;
+			public const int tabPaddingEnd = 2130903452;
 			
 			// aapt resource value: 0x7F03019D
-			public const int tabPaddingTop = 2130903453;
+			public const int tabPaddingStart = 2130903453;
 			
 			// aapt resource value: 0x7F03019E
-			public const int tabRippleColor = 2130903454;
+			public const int tabPaddingTop = 2130903454;
 			
 			// aapt resource value: 0x7F03019F
-			public const int tabSelectedTextColor = 2130903455;
+			public const int tabRippleColor = 2130903455;
 			
 			// aapt resource value: 0x7F0301A0
-			public const int tabStyle = 2130903456;
+			public const int tabSelectedTextColor = 2130903456;
 			
 			// aapt resource value: 0x7F0301A1
-			public const int tabTextAppearance = 2130903457;
+			public const int tabStyle = 2130903457;
 			
 			// aapt resource value: 0x7F0301A2
-			public const int tabTextColor = 2130903458;
+			public const int tabTextAppearance = 2130903458;
 			
 			// aapt resource value: 0x7F0301A3
-			public const int tabUnboundedRipple = 2130903459;
+			public const int tabTextColor = 2130903459;
 			
 			// aapt resource value: 0x7F0301A4
-			public const int textAllCaps = 2130903460;
+			public const int tabUnboundedRipple = 2130903460;
 			
 			// aapt resource value: 0x7F0301A5
-			public const int textAppearanceBody1 = 2130903461;
+			public const int textAllCaps = 2130903461;
 			
 			// aapt resource value: 0x7F0301A6
-			public const int textAppearanceBody2 = 2130903462;
+			public const int textAppearanceBody1 = 2130903462;
 			
 			// aapt resource value: 0x7F0301A7
-			public const int textAppearanceButton = 2130903463;
+			public const int textAppearanceBody2 = 2130903463;
 			
 			// aapt resource value: 0x7F0301A8
-			public const int textAppearanceCaption = 2130903464;
+			public const int textAppearanceButton = 2130903464;
 			
 			// aapt resource value: 0x7F0301A9
-			public const int textAppearanceHeadline1 = 2130903465;
+			public const int textAppearanceCaption = 2130903465;
 			
 			// aapt resource value: 0x7F0301AA
-			public const int textAppearanceHeadline2 = 2130903466;
+			public const int textAppearanceHeadline1 = 2130903466;
 			
 			// aapt resource value: 0x7F0301AB
-			public const int textAppearanceHeadline3 = 2130903467;
+			public const int textAppearanceHeadline2 = 2130903467;
 			
 			// aapt resource value: 0x7F0301AC
-			public const int textAppearanceHeadline4 = 2130903468;
+			public const int textAppearanceHeadline3 = 2130903468;
 			
 			// aapt resource value: 0x7F0301AD
-			public const int textAppearanceHeadline5 = 2130903469;
+			public const int textAppearanceHeadline4 = 2130903469;
 			
 			// aapt resource value: 0x7F0301AE
-			public const int textAppearanceHeadline6 = 2130903470;
+			public const int textAppearanceHeadline5 = 2130903470;
 			
 			// aapt resource value: 0x7F0301AF
-			public const int textAppearanceLargePopupMenu = 2130903471;
+			public const int textAppearanceHeadline6 = 2130903471;
 			
 			// aapt resource value: 0x7F0301B0
-			public const int textAppearanceListItem = 2130903472;
+			public const int textAppearanceLargePopupMenu = 2130903472;
 			
 			// aapt resource value: 0x7F0301B1
-			public const int textAppearanceListItemSecondary = 2130903473;
+			public const int textAppearanceListItem = 2130903473;
 			
 			// aapt resource value: 0x7F0301B2
-			public const int textAppearanceListItemSmall = 2130903474;
+			public const int textAppearanceListItemSecondary = 2130903474;
 			
 			// aapt resource value: 0x7F0301B3
-			public const int textAppearanceOverline = 2130903475;
+			public const int textAppearanceListItemSmall = 2130903475;
 			
 			// aapt resource value: 0x7F0301B4
-			public const int textAppearancePopupMenuHeader = 2130903476;
+			public const int textAppearanceOverline = 2130903476;
 			
 			// aapt resource value: 0x7F0301B5
-			public const int textAppearanceSearchResultSubtitle = 2130903477;
+			public const int textAppearancePopupMenuHeader = 2130903477;
 			
 			// aapt resource value: 0x7F0301B6
-			public const int textAppearanceSearchResultTitle = 2130903478;
+			public const int textAppearanceSearchResultSubtitle = 2130903478;
 			
 			// aapt resource value: 0x7F0301B7
-			public const int textAppearanceSmallPopupMenu = 2130903479;
+			public const int textAppearanceSearchResultTitle = 2130903479;
 			
 			// aapt resource value: 0x7F0301B8
-			public const int textAppearanceSubtitle1 = 2130903480;
+			public const int textAppearanceSmallPopupMenu = 2130903480;
 			
 			// aapt resource value: 0x7F0301B9
-			public const int textAppearanceSubtitle2 = 2130903481;
+			public const int textAppearanceSubtitle1 = 2130903481;
 			
 			// aapt resource value: 0x7F0301BA
-			public const int textColorAlertDialogListItem = 2130903482;
+			public const int textAppearanceSubtitle2 = 2130903482;
 			
 			// aapt resource value: 0x7F0301BB
-			public const int textColorSearchUrl = 2130903483;
+			public const int textColorAlertDialogListItem = 2130903483;
 			
 			// aapt resource value: 0x7F0301BC
-			public const int textEndPadding = 2130903484;
+			public const int textColorSearchUrl = 2130903484;
 			
 			// aapt resource value: 0x7F0301BD
-			public const int textInputStyle = 2130903485;
+			public const int textEndPadding = 2130903485;
 			
 			// aapt resource value: 0x7F0301BE
-			public const int textStartPadding = 2130903486;
+			public const int textInputStyle = 2130903486;
 			
 			// aapt resource value: 0x7F0301BF
-			public const int theme = 2130903487;
+			public const int textStartPadding = 2130903487;
 			
 			// aapt resource value: 0x7F0301C0
-			public const int thickness = 2130903488;
+			public const int theme = 2130903488;
 			
 			// aapt resource value: 0x7F0301C1
-			public const int thumbTextPadding = 2130903489;
+			public const int thickness = 2130903489;
 			
 			// aapt resource value: 0x7F0301C2
-			public const int thumbTint = 2130903490;
+			public const int thumbTextPadding = 2130903490;
 			
 			// aapt resource value: 0x7F0301C3
-			public const int thumbTintMode = 2130903491;
+			public const int thumbTint = 2130903491;
 			
 			// aapt resource value: 0x7F0301C4
-			public const int tickMark = 2130903492;
+			public const int thumbTintMode = 2130903492;
 			
 			// aapt resource value: 0x7F0301C5
-			public const int tickMarkTint = 2130903493;
+			public const int tickMark = 2130903493;
 			
 			// aapt resource value: 0x7F0301C6
-			public const int tickMarkTintMode = 2130903494;
+			public const int tickMarkTint = 2130903494;
 			
 			// aapt resource value: 0x7F0301C7
-			public const int tint = 2130903495;
+			public const int tickMarkTintMode = 2130903495;
 			
 			// aapt resource value: 0x7F0301C8
-			public const int tintMode = 2130903496;
+			public const int tint = 2130903496;
 			
 			// aapt resource value: 0x7F0301C9
-			public const int title = 2130903497;
+			public const int tintMode = 2130903497;
 			
 			// aapt resource value: 0x7F0301CA
-			public const int titleEnabled = 2130903498;
+			public const int title = 2130903498;
 			
 			// aapt resource value: 0x7F0301CB
-			public const int titleMargin = 2130903499;
+			public const int titleEnabled = 2130903499;
 			
 			// aapt resource value: 0x7F0301CC
-			public const int titleMarginBottom = 2130903500;
+			public const int titleMargin = 2130903500;
 			
 			// aapt resource value: 0x7F0301CD
-			public const int titleMarginEnd = 2130903501;
-			
-			// aapt resource value: 0x7F0301D0
-			public const int titleMargins = 2130903504;
+			public const int titleMarginBottom = 2130903501;
 			
 			// aapt resource value: 0x7F0301CE
-			public const int titleMarginStart = 2130903502;
-			
-			// aapt resource value: 0x7F0301CF
-			public const int titleMarginTop = 2130903503;
+			public const int titleMarginEnd = 2130903502;
 			
 			// aapt resource value: 0x7F0301D1
-			public const int titleTextAppearance = 2130903505;
+			public const int titleMargins = 2130903505;
+			
+			// aapt resource value: 0x7F0301CF
+			public const int titleMarginStart = 2130903503;
+			
+			// aapt resource value: 0x7F0301D0
+			public const int titleMarginTop = 2130903504;
 			
 			// aapt resource value: 0x7F0301D2
-			public const int titleTextColor = 2130903506;
+			public const int titleTextAppearance = 2130903506;
 			
 			// aapt resource value: 0x7F0301D3
-			public const int titleTextStyle = 2130903507;
+			public const int titleTextColor = 2130903507;
 			
 			// aapt resource value: 0x7F0301D4
-			public const int toolbarId = 2130903508;
+			public const int titleTextStyle = 2130903508;
 			
 			// aapt resource value: 0x7F0301D5
-			public const int toolbarNavigationButtonStyle = 2130903509;
+			public const int toolbarId = 2130903509;
 			
 			// aapt resource value: 0x7F0301D6
-			public const int toolbarStyle = 2130903510;
+			public const int toolbarNavigationButtonStyle = 2130903510;
 			
 			// aapt resource value: 0x7F0301D7
-			public const int tooltipForegroundColor = 2130903511;
+			public const int toolbarStyle = 2130903511;
 			
 			// aapt resource value: 0x7F0301D8
-			public const int tooltipFrameBackground = 2130903512;
+			public const int tooltipForegroundColor = 2130903512;
 			
 			// aapt resource value: 0x7F0301D9
-			public const int tooltipText = 2130903513;
+			public const int tooltipFrameBackground = 2130903513;
 			
 			// aapt resource value: 0x7F0301DA
-			public const int track = 2130903514;
+			public const int tooltipText = 2130903514;
 			
 			// aapt resource value: 0x7F0301DB
-			public const int trackTint = 2130903515;
+			public const int track = 2130903515;
 			
 			// aapt resource value: 0x7F0301DC
-			public const int trackTintMode = 2130903516;
+			public const int trackTint = 2130903516;
 			
 			// aapt resource value: 0x7F0301DD
-			public const int ttcIndex = 2130903517;
+			public const int trackTintMode = 2130903517;
 			
 			// aapt resource value: 0x7F0301DE
-			public const int useCompatPadding = 2130903518;
+			public const int ttcIndex = 2130903518;
 			
 			// aapt resource value: 0x7F0301DF
-			public const int viewInflaterClass = 2130903519;
+			public const int useCompatPadding = 2130903519;
 			
 			// aapt resource value: 0x7F0301E0
-			public const int voiceIcon = 2130903520;
+			public const int viewInflaterClass = 2130903520;
 			
 			// aapt resource value: 0x7F0301E1
-			public const int windowActionBar = 2130903521;
+			public const int voiceIcon = 2130903521;
 			
 			// aapt resource value: 0x7F0301E2
-			public const int windowActionBarOverlay = 2130903522;
+			public const int windowActionBar = 2130903522;
 			
 			// aapt resource value: 0x7F0301E3
-			public const int windowActionModeOverlay = 2130903523;
+			public const int windowActionBarOverlay = 2130903523;
 			
 			// aapt resource value: 0x7F0301E4
-			public const int windowFixedHeightMajor = 2130903524;
+			public const int windowActionModeOverlay = 2130903524;
 			
 			// aapt resource value: 0x7F0301E5
-			public const int windowFixedHeightMinor = 2130903525;
+			public const int windowFixedHeightMajor = 2130903525;
 			
 			// aapt resource value: 0x7F0301E6
-			public const int windowFixedWidthMajor = 2130903526;
+			public const int windowFixedHeightMinor = 2130903526;
 			
 			// aapt resource value: 0x7F0301E7
-			public const int windowFixedWidthMinor = 2130903527;
+			public const int windowFixedWidthMajor = 2130903527;
 			
 			// aapt resource value: 0x7F0301E8
-			public const int windowMinWidthMajor = 2130903528;
+			public const int windowFixedWidthMinor = 2130903528;
 			
 			// aapt resource value: 0x7F0301E9
-			public const int windowMinWidthMinor = 2130903529;
+			public const int windowMinWidthMajor = 2130903529;
 			
 			// aapt resource value: 0x7F0301EA
-			public const int windowNoTitle = 2130903530;
+			public const int windowMinWidthMinor = 2130903530;
+			
+			// aapt resource value: 0x7F0301EB
+			public const int windowNoTitle = 2130903531;
 			
 			static Attribute()
 			{
@@ -10413,25 +10426,28 @@ namespace Playground.Droid
 			public const int mtrl_chip_close_icon_content_description = 2131558470;
 			
 			// aapt resource value: 0x7F0D0047
-			public const int password_toggle_content_description = 2131558471;
+			public const int overflow_tab_title = 2131558471;
 			
 			// aapt resource value: 0x7F0D0048
-			public const int path_password_eye = 2131558472;
+			public const int password_toggle_content_description = 2131558472;
 			
 			// aapt resource value: 0x7F0D0049
-			public const int path_password_eye_mask_strike_through = 2131558473;
+			public const int path_password_eye = 2131558473;
 			
 			// aapt resource value: 0x7F0D004A
-			public const int path_password_eye_mask_visible = 2131558474;
+			public const int path_password_eye_mask_strike_through = 2131558474;
 			
 			// aapt resource value: 0x7F0D004B
-			public const int path_password_strike_through = 2131558475;
+			public const int path_password_eye_mask_visible = 2131558475;
 			
 			// aapt resource value: 0x7F0D004C
-			public const int search_menu_title = 2131558476;
+			public const int path_password_strike_through = 2131558476;
 			
 			// aapt resource value: 0x7F0D004D
-			public const int status_bar_notification_info_overflow = 2131558477;
+			public const int search_menu_title = 2131558477;
+			
+			// aapt resource value: 0x7F0D004E
+			public const int status_bar_notification_info_overflow = 2131558478;
 			
 			static String()
 			{
@@ -11041,7 +11057,10 @@ namespace Playground.Droid
 			public const int CardView_Light = 2131624133;
 			
 			// aapt resource value: 0x7F0E0202
-			public const int collectionViewStyle = 2131624450;
+			public const int collectionViewScrollBars = 2131624450;
+			
+			// aapt resource value: 0x7F0E0203
+			public const int collectionViewTheme = 2131624451;
 			
 			// aapt resource value: 0x7F0E00C6
 			public const int MainTheme = 2131624134;
@@ -12004,37 +12023,37 @@ namespace Playground.Droid
 		public partial class Styleable
 		{
 			
-			// aapt resource value: { 0x7F030031,0x7F030032,0x7F030033,0x7F030091,0x7F030092,0x7F030093,0x7F030094,0x7F030095,0x7F030096,0x7F0300A4,0x7F0300A9,0x7F0300AA,0x7F0300B5,0x7F0300E0,0x7F0300E5,0x7F0300EA,0x7F0300EB,0x7F0300ED,0x7F0300F7,0x7F030101,0x7F030124,0x7F03013D,0x7F03014E,0x7F030152,0x7F030153,0x7F030181,0x7F030184,0x7F0301C9,0x7F0301D3 }
+			// aapt resource value: { 0x7F030031,0x7F030032,0x7F030033,0x7F030092,0x7F030093,0x7F030094,0x7F030095,0x7F030096,0x7F030097,0x7F0300A5,0x7F0300AA,0x7F0300AB,0x7F0300B6,0x7F0300E1,0x7F0300E6,0x7F0300EB,0x7F0300EC,0x7F0300EE,0x7F0300F8,0x7F030102,0x7F030125,0x7F03013E,0x7F03014F,0x7F030153,0x7F030154,0x7F030182,0x7F030185,0x7F0301CA,0x7F0301D4 }
 			public static int[] ActionBar = new int[] {
 					2130903089,
 					2130903090,
 					2130903091,
-					2130903185,
 					2130903186,
 					2130903187,
 					2130903188,
 					2130903189,
 					2130903190,
-					2130903204,
-					2130903209,
+					2130903191,
+					2130903205,
 					2130903210,
-					2130903221,
-					2130903264,
-					2130903269,
-					2130903274,
+					2130903211,
+					2130903222,
+					2130903265,
+					2130903270,
 					2130903275,
-					2130903277,
-					2130903287,
-					2130903297,
-					2130903332,
-					2130903357,
-					2130903374,
-					2130903378,
+					2130903276,
+					2130903278,
+					2130903288,
+					2130903298,
+					2130903333,
+					2130903358,
+					2130903375,
 					2130903379,
-					2130903425,
-					2130903428,
-					2130903497,
-					2130903507};
+					2130903380,
+					2130903426,
+					2130903429,
+					2130903498,
+					2130903508};
 			
 			// aapt resource value: { 0x10100B3 }
 			public static int[] ActionBarLayout = new int[] {
@@ -12141,14 +12160,14 @@ namespace Playground.Droid
 			public static int[] ActionMenuView = new int[] {
 					-1};
 			
-			// aapt resource value: { 0x7F030031,0x7F030032,0x7F03007E,0x7F0300E0,0x7F030184,0x7F0301D3 }
+			// aapt resource value: { 0x7F030031,0x7F030032,0x7F03007E,0x7F0300E1,0x7F030185,0x7F0301D4 }
 			public static int[] ActionMode = new int[] {
 					2130903089,
 					2130903090,
 					2130903166,
-					2130903264,
-					2130903428,
-					2130903507};
+					2130903265,
+					2130903429,
+					2130903508};
 			
 			// aapt resource value: 0
 			public const int ActionMode_background = 0;
@@ -12168,10 +12187,10 @@ namespace Playground.Droid
 			// aapt resource value: 5
 			public const int ActionMode_titleTextStyle = 5;
 			
-			// aapt resource value: { 0x7F0300BA,0x7F0300F8 }
+			// aapt resource value: { 0x7F0300BB,0x7F0300F9 }
 			public static int[] ActivityChooserView = new int[] {
-					2130903226,
-					2130903288};
+					2130903227,
+					2130903289};
 			
 			// aapt resource value: 0
 			public const int ActivityChooserView_expandActivityOverflowButtonDrawable = 0;
@@ -12179,16 +12198,16 @@ namespace Playground.Droid
 			// aapt resource value: 1
 			public const int ActivityChooserView_initialActivityCount = 1;
 			
-			// aapt resource value: { 0x10100F2,0x7F030052,0x7F030053,0x7F03011B,0x7F03011C,0x7F03013A,0x7F030169,0x7F03016A }
+			// aapt resource value: { 0x10100F2,0x7F030052,0x7F030053,0x7F03011C,0x7F03011D,0x7F03013B,0x7F03016A,0x7F03016B }
 			public static int[] AlertDialog = new int[] {
 					16842994,
 					2130903122,
 					2130903123,
-					2130903323,
 					2130903324,
-					2130903354,
-					2130903401,
-					2130903402};
+					2130903325,
+					2130903355,
+					2130903402,
+					2130903403};
 			
 			// aapt resource value: 0
 			public const int AlertDialog_android_layout = 0;
@@ -12271,21 +12290,21 @@ namespace Playground.Droid
 			// aapt resource value: 1
 			public const int AnimatedStateListDrawableTransition_android_toId = 1;
 			
-			// aapt resource value: { 0x10100D4,0x101048F,0x1010540,0x7F0300B5,0x7F0300BB,0x7F030116 }
+			// aapt resource value: { 0x10100D4,0x101048F,0x1010540,0x7F0300B6,0x7F0300BC,0x7F030117 }
 			public static int[] AppBarLayout = new int[] {
 					16842964,
 					16843919,
 					16844096,
-					2130903221,
-					2130903227,
-					2130903318};
+					2130903222,
+					2130903228,
+					2130903319};
 			
-			// aapt resource value: { 0x7F030177,0x7F030178,0x7F030179,0x7F03017A }
+			// aapt resource value: { 0x7F030178,0x7F030179,0x7F03017A,0x7F03017B }
 			public static int[] AppBarLayoutStates = new int[] {
-					2130903415,
 					2130903416,
 					2130903417,
-					2130903418};
+					2130903418,
+					2130903419};
 			
 			// aapt resource value: 0
 			public const int AppBarLayoutStates_state_collapsed = 0;
@@ -12314,10 +12333,10 @@ namespace Playground.Droid
 			// aapt resource value: 4
 			public const int AppBarLayout_expanded = 4;
 			
-			// aapt resource value: { 0x7F030114,0x7F030115 }
+			// aapt resource value: { 0x7F030115,0x7F030116 }
 			public static int[] AppBarLayout_Layout = new int[] {
-					2130903316,
-					2130903317};
+					2130903317,
+					2130903318};
 			
 			// aapt resource value: 0
 			public const int AppBarLayout_Layout_layout_scrollFlags = 0;
@@ -12328,12 +12347,12 @@ namespace Playground.Droid
 			// aapt resource value: 5
 			public const int AppBarLayout_liftOnScroll = 5;
 			
-			// aapt resource value: { 0x1010119,0x7F030174,0x7F0301C7,0x7F0301C8 }
+			// aapt resource value: { 0x1010119,0x7F030175,0x7F0301C8,0x7F0301C9 }
 			public static int[] AppCompatImageView = new int[] {
 					16843033,
-					2130903412,
-					2130903495,
-					2130903496};
+					2130903413,
+					2130903496,
+					2130903497};
 			
 			// aapt resource value: 0
 			public const int AppCompatImageView_android_src = 0;
@@ -12347,12 +12366,12 @@ namespace Playground.Droid
 			// aapt resource value: 3
 			public const int AppCompatImageView_tintMode = 3;
 			
-			// aapt resource value: { 0x1010142,0x7F0301C4,0x7F0301C5,0x7F0301C6 }
+			// aapt resource value: { 0x1010142,0x7F0301C5,0x7F0301C6,0x7F0301C7 }
 			public static int[] AppCompatSeekBar = new int[] {
 					16843074,
-					2130903492,
 					2130903493,
-					2130903494};
+					2130903494,
+					2130903495};
 			
 			// aapt resource value: 0
 			public const int AppCompatSeekBar_android_thumb = 0;
@@ -12397,7 +12416,7 @@ namespace Playground.Droid
 			// aapt resource value: 0
 			public const int AppCompatTextHelper_android_textAppearance = 0;
 			
-			// aapt resource value: { 0x1010034,0x7F03002C,0x7F03002D,0x7F03002E,0x7F03002F,0x7F030030,0x7F0300CF,0x7F0300D2,0x7F030109,0x7F030117,0x7F0301A4 }
+			// aapt resource value: { 0x1010034,0x7F03002C,0x7F03002D,0x7F03002E,0x7F03002F,0x7F030030,0x7F0300D0,0x7F0300D3,0x7F03010A,0x7F030118,0x7F0301A5 }
 			public static int[] AppCompatTextView = new int[] {
 					16842804,
 					2130903084,
@@ -12405,11 +12424,11 @@ namespace Playground.Droid
 					2130903086,
 					2130903087,
 					2130903088,
-					2130903247,
-					2130903250,
-					2130903305,
-					2130903319,
-					2130903460};
+					2130903248,
+					2130903251,
+					2130903306,
+					2130903320,
+					2130903461};
 			
 			// aapt resource value: 0
 			public const int AppCompatTextView_android_textAppearance = 0;
@@ -12444,7 +12463,7 @@ namespace Playground.Droid
 			// aapt resource value: 10
 			public const int AppCompatTextView_textAllCaps = 10;
 			
-			// aapt resource value: { 0x1010057,0x10100AE,0x7F030000,0x7F030001,0x7F030002,0x7F030003,0x7F030004,0x7F030005,0x7F030006,0x7F030007,0x7F030008,0x7F030009,0x7F03000A,0x7F03000B,0x7F03000C,0x7F03000E,0x7F03000F,0x7F030010,0x7F030011,0x7F030012,0x7F030013,0x7F030014,0x7F030015,0x7F030016,0x7F030017,0x7F030018,0x7F030019,0x7F03001A,0x7F03001B,0x7F03001C,0x7F03001D,0x7F03001E,0x7F030021,0x7F030022,0x7F030023,0x7F030024,0x7F030025,0x7F03002B,0x7F03003E,0x7F03004C,0x7F03004D,0x7F03004E,0x7F03004F,0x7F030050,0x7F030054,0x7F030055,0x7F03005F,0x7F030064,0x7F030084,0x7F030085,0x7F030086,0x7F030087,0x7F030088,0x7F030089,0x7F03008A,0x7F03008B,0x7F03008C,0x7F03008E,0x7F03009D,0x7F0300A6,0x7F0300A7,0x7F0300A8,0x7F0300AB,0x7F0300AD,0x7F0300B0,0x7F0300B1,0x7F0300B2,0x7F0300B3,0x7F0300B4,0x7F0300EA,0x7F0300F6,0x7F030119,0x7F03011A,0x7F03011D,0x7F03011E,0x7F03011F,0x7F030120,0x7F030121,0x7F030122,0x7F030123,0x7F030145,0x7F030146,0x7F030147,0x7F03014D,0x7F03014F,0x7F030156,0x7F030157,0x7F030158,0x7F030159,0x7F030161,0x7F030162,0x7F030163,0x7F030164,0x7F030171,0x7F030172,0x7F030188,0x7F0301AF,0x7F0301B0,0x7F0301B1,0x7F0301B2,0x7F0301B4,0x7F0301B5,0x7F0301B6,0x7F0301B7,0x7F0301BA,0x7F0301BB,0x7F0301D5,0x7F0301D6,0x7F0301D7,0x7F0301D8,0x7F0301DF,0x7F0301E1,0x7F0301E2,0x7F0301E3,0x7F0301E4,0x7F0301E5,0x7F0301E6,0x7F0301E7,0x7F0301E8,0x7F0301E9,0x7F0301EA }
+			// aapt resource value: { 0x1010057,0x10100AE,0x7F030000,0x7F030001,0x7F030002,0x7F030003,0x7F030004,0x7F030005,0x7F030006,0x7F030007,0x7F030008,0x7F030009,0x7F03000A,0x7F03000B,0x7F03000C,0x7F03000E,0x7F03000F,0x7F030010,0x7F030011,0x7F030012,0x7F030013,0x7F030014,0x7F030015,0x7F030016,0x7F030017,0x7F030018,0x7F030019,0x7F03001A,0x7F03001B,0x7F03001C,0x7F03001D,0x7F03001E,0x7F030021,0x7F030022,0x7F030023,0x7F030024,0x7F030025,0x7F03002B,0x7F03003E,0x7F03004C,0x7F03004D,0x7F03004E,0x7F03004F,0x7F030050,0x7F030054,0x7F030055,0x7F03005F,0x7F030064,0x7F030085,0x7F030086,0x7F030087,0x7F030088,0x7F030089,0x7F03008A,0x7F03008B,0x7F03008C,0x7F03008D,0x7F03008F,0x7F03009E,0x7F0300A7,0x7F0300A8,0x7F0300A9,0x7F0300AC,0x7F0300AE,0x7F0300B1,0x7F0300B2,0x7F0300B3,0x7F0300B4,0x7F0300B5,0x7F0300EB,0x7F0300F7,0x7F03011A,0x7F03011B,0x7F03011E,0x7F03011F,0x7F030120,0x7F030121,0x7F030122,0x7F030123,0x7F030124,0x7F030146,0x7F030147,0x7F030148,0x7F03014E,0x7F030150,0x7F030157,0x7F030158,0x7F030159,0x7F03015A,0x7F030162,0x7F030163,0x7F030164,0x7F030165,0x7F030172,0x7F030173,0x7F030189,0x7F0301B0,0x7F0301B1,0x7F0301B2,0x7F0301B3,0x7F0301B5,0x7F0301B6,0x7F0301B7,0x7F0301B8,0x7F0301BB,0x7F0301BC,0x7F0301D6,0x7F0301D7,0x7F0301D8,0x7F0301D9,0x7F0301E0,0x7F0301E2,0x7F0301E3,0x7F0301E4,0x7F0301E5,0x7F0301E6,0x7F0301E7,0x7F0301E8,0x7F0301E9,0x7F0301EA,0x7F0301EB }
 			public static int[] AppCompatTheme = new int[] {
 					16842839,
 					16842926,
@@ -12494,7 +12513,6 @@ namespace Playground.Droid
 					2130903125,
 					2130903135,
 					2130903140,
-					2130903172,
 					2130903173,
 					2130903174,
 					2130903175,
@@ -12503,61 +12521,61 @@ namespace Playground.Droid
 					2130903178,
 					2130903179,
 					2130903180,
-					2130903182,
-					2130903197,
-					2130903206,
+					2130903181,
+					2130903183,
+					2130903198,
 					2130903207,
 					2130903208,
-					2130903211,
-					2130903213,
-					2130903216,
+					2130903209,
+					2130903212,
+					2130903214,
 					2130903217,
 					2130903218,
 					2130903219,
 					2130903220,
-					2130903274,
-					2130903286,
-					2130903321,
+					2130903221,
+					2130903275,
+					2130903287,
 					2130903322,
-					2130903325,
+					2130903323,
 					2130903326,
 					2130903327,
 					2130903328,
 					2130903329,
 					2130903330,
 					2130903331,
-					2130903365,
+					2130903332,
 					2130903366,
 					2130903367,
-					2130903373,
-					2130903375,
-					2130903382,
+					2130903368,
+					2130903374,
+					2130903376,
 					2130903383,
 					2130903384,
 					2130903385,
-					2130903393,
+					2130903386,
 					2130903394,
 					2130903395,
 					2130903396,
-					2130903409,
+					2130903397,
 					2130903410,
-					2130903432,
-					2130903471,
+					2130903411,
+					2130903433,
 					2130903472,
 					2130903473,
 					2130903474,
-					2130903476,
+					2130903475,
 					2130903477,
 					2130903478,
 					2130903479,
-					2130903482,
+					2130903480,
 					2130903483,
-					2130903509,
+					2130903484,
 					2130903510,
 					2130903511,
 					2130903512,
-					2130903519,
-					2130903521,
+					2130903513,
+					2130903520,
 					2130903522,
 					2130903523,
 					2130903524,
@@ -12566,7 +12584,8 @@ namespace Playground.Droid
 					2130903527,
 					2130903528,
 					2130903529,
-					2130903530};
+					2130903530,
+					2130903531};
 			
 			// aapt resource value: 2
 			public const int AppCompatTheme_actionBarDivider = 2;
@@ -12931,14 +12950,14 @@ namespace Playground.Droid
 			// aapt resource value: 120
 			public const int AppCompatTheme_windowNoTitle = 120;
 			
-			// aapt resource value: { 0x7F030034,0x7F0300C4,0x7F0300C5,0x7F0300C6,0x7F0300C7,0x7F0300E6 }
+			// aapt resource value: { 0x7F030034,0x7F0300C5,0x7F0300C6,0x7F0300C7,0x7F0300C8,0x7F0300E7 }
 			public static int[] BottomAppBar = new int[] {
 					2130903092,
-					2130903236,
 					2130903237,
 					2130903238,
 					2130903239,
-					2130903270};
+					2130903240,
+					2130903271};
 			
 			// aapt resource value: 0
 			public const int BottomAppBar_backgroundTint = 0;
@@ -12958,18 +12977,18 @@ namespace Playground.Droid
 			// aapt resource value: 5
 			public const int BottomAppBar_hideOnScroll = 5;
 			
-			// aapt resource value: { 0x7F0300B5,0x7F0300FB,0x7F0300FD,0x7F0300FF,0x7F030100,0x7F030104,0x7F030105,0x7F030106,0x7F030108,0x7F030139 }
+			// aapt resource value: { 0x7F0300B6,0x7F0300FC,0x7F0300FE,0x7F030100,0x7F030101,0x7F030105,0x7F030106,0x7F030107,0x7F030109,0x7F03013A }
 			public static int[] BottomNavigationView = new int[] {
-					2130903221,
-					2130903291,
-					2130903293,
-					2130903295,
+					2130903222,
+					2130903292,
+					2130903294,
 					2130903296,
-					2130903300,
+					2130903297,
 					2130903301,
 					2130903302,
-					2130903304,
-					2130903353};
+					2130903303,
+					2130903305,
+					2130903354};
 			
 			// aapt resource value: 0
 			public const int BottomNavigationView_elevation = 0;
@@ -13027,7 +13046,7 @@ namespace Playground.Droid
 			// aapt resource value: 0
 			public const int ButtonBarLayout_allowStacking = 0;
 			
-			// aapt resource value: { 0x101013F,0x1010140,0x7F030058,0x7F030059,0x7F03005A,0x7F03005B,0x7F03005C,0x7F03005D,0x7F030097,0x7F030098,0x7F030099,0x7F03009A,0x7F03009B }
+			// aapt resource value: { 0x101013F,0x1010140,0x7F030058,0x7F030059,0x7F03005A,0x7F03005B,0x7F03005C,0x7F03005D,0x7F030098,0x7F030099,0x7F03009A,0x7F03009B,0x7F03009C }
 			public static int[] CardView = new int[] {
 					16843071,
 					16843072,
@@ -13037,11 +13056,11 @@ namespace Playground.Droid
 					2130903131,
 					2130903132,
 					2130903133,
-					2130903191,
 					2130903192,
 					2130903193,
 					2130903194,
-					2130903195};
+					2130903195,
+					2130903196};
 			
 			// aapt resource value: 1
 			public const int CardView_android_minHeight = 1;
@@ -13082,7 +13101,7 @@ namespace Playground.Droid
 			// aapt resource value: 12
 			public const int CardView_contentPaddingTop = 12;
 			
-			// aapt resource value: { 0x1010034,0x10100AB,0x101011F,0x101014F,0x10101E5,0x7F030061,0x7F030062,0x7F030063,0x7F030065,0x7F030066,0x7F030067,0x7F030069,0x7F03006A,0x7F03006B,0x7F03006C,0x7F03006D,0x7F03006E,0x7F030073,0x7F030074,0x7F030075,0x7F030077,0x7F030078,0x7F030079,0x7F03007A,0x7F03007B,0x7F03007C,0x7F03007D,0x7F0300E4,0x7F0300EE,0x7F0300F2,0x7F03015B,0x7F030167,0x7F0301BC,0x7F0301BE }
+			// aapt resource value: { 0x1010034,0x10100AB,0x101011F,0x101014F,0x10101E5,0x7F030061,0x7F030062,0x7F030063,0x7F030065,0x7F030066,0x7F030067,0x7F030069,0x7F03006A,0x7F03006B,0x7F03006C,0x7F03006D,0x7F03006E,0x7F030073,0x7F030074,0x7F030075,0x7F030077,0x7F030078,0x7F030079,0x7F03007A,0x7F03007B,0x7F03007C,0x7F03007D,0x7F0300E5,0x7F0300EF,0x7F0300F3,0x7F03015C,0x7F030168,0x7F0301BD,0x7F0301BF }
 			public static int[] Chip = new int[] {
 					16842804,
 					16842923,
@@ -13111,22 +13130,22 @@ namespace Playground.Droid
 					2130903163,
 					2130903164,
 					2130903165,
-					2130903268,
-					2130903278,
-					2130903282,
-					2130903387,
-					2130903399,
-					2130903484,
-					2130903486};
+					2130903269,
+					2130903279,
+					2130903283,
+					2130903388,
+					2130903400,
+					2130903485,
+					2130903487};
 			
-			// aapt resource value: { 0x7F030060,0x7F03006F,0x7F030070,0x7F030071,0x7F03016B,0x7F03016C }
+			// aapt resource value: { 0x7F030060,0x7F03006F,0x7F030070,0x7F030071,0x7F03016C,0x7F03016D }
 			public static int[] ChipGroup = new int[] {
 					2130903136,
 					2130903151,
 					2130903152,
 					2130903153,
-					2130903403,
-					2130903404};
+					2130903404,
+					2130903405};
 			
 			// aapt resource value: 0
 			public const int ChipGroup_checkedChip = 0;
@@ -13248,24 +13267,24 @@ namespace Playground.Droid
 			// aapt resource value: 33
 			public const int Chip_textStartPadding = 33;
 			
-			// aapt resource value: { 0x7F030081,0x7F030082,0x7F03009C,0x7F0300BC,0x7F0300BD,0x7F0300BE,0x7F0300BF,0x7F0300C0,0x7F0300C1,0x7F0300C2,0x7F03015C,0x7F03015E,0x7F03017C,0x7F0301C9,0x7F0301CA,0x7F0301D4 }
+			// aapt resource value: { 0x7F030081,0x7F030082,0x7F03009D,0x7F0300BD,0x7F0300BE,0x7F0300BF,0x7F0300C0,0x7F0300C1,0x7F0300C2,0x7F0300C3,0x7F03015D,0x7F03015F,0x7F03017D,0x7F0301CA,0x7F0301CB,0x7F0301D5 }
 			public static int[] CollapsingToolbarLayout = new int[] {
 					2130903169,
 					2130903170,
-					2130903196,
-					2130903228,
+					2130903197,
 					2130903229,
 					2130903230,
 					2130903231,
 					2130903232,
 					2130903233,
 					2130903234,
-					2130903388,
-					2130903390,
-					2130903420,
-					2130903497,
+					2130903235,
+					2130903389,
+					2130903391,
+					2130903421,
 					2130903498,
-					2130903508};
+					2130903499,
+					2130903509};
 			
 			// aapt resource value: 0
 			public const int CollapsingToolbarLayout_collapsedTitleGravity = 0;
@@ -13297,10 +13316,10 @@ namespace Playground.Droid
 			// aapt resource value: 9
 			public const int CollapsingToolbarLayout_expandedTitleTextAppearance = 9;
 			
-			// aapt resource value: { 0x7F03010F,0x7F030110 }
+			// aapt resource value: { 0x7F030110,0x7F030111 }
 			public static int[] CollapsingToolbarLayout_Layout = new int[] {
-					2130903311,
-					2130903312};
+					2130903312,
+					2130903313};
 			
 			// aapt resource value: 0
 			public const int CollapsingToolbarLayout_Layout_layout_collapseMode = 0;
@@ -13356,23 +13375,23 @@ namespace Playground.Droid
 			// aapt resource value: 2
 			public const int CompoundButton_buttonTintMode = 2;
 			
-			// aapt resource value: { 0x7F030107,0x7F03017B }
+			// aapt resource value: { 0x7F030108,0x7F03017C }
 			public static int[] CoordinatorLayout = new int[] {
-					2130903303,
-					2130903419};
+					2130903304,
+					2130903420};
 			
 			// aapt resource value: 0
 			public const int CoordinatorLayout_keylines = 0;
 			
-			// aapt resource value: { 0x10100B3,0x7F03010C,0x7F03010D,0x7F03010E,0x7F030111,0x7F030112,0x7F030113 }
+			// aapt resource value: { 0x10100B3,0x7F03010D,0x7F03010E,0x7F03010F,0x7F030112,0x7F030113,0x7F030114 }
 			public static int[] CoordinatorLayout_Layout = new int[] {
 					16842931,
-					2130903308,
 					2130903309,
 					2130903310,
-					2130903313,
+					2130903311,
 					2130903314,
-					2130903315};
+					2130903315,
+					2130903316};
 			
 			// aapt resource value: 0
 			public const int CoordinatorLayout_Layout_android_layout_gravity = 0;
@@ -13409,16 +13428,16 @@ namespace Playground.Droid
 			// aapt resource value: 1
 			public const int DesignTheme_bottomSheetStyle = 1;
 			
-			// aapt resource value: { 0x7F030029,0x7F03002A,0x7F030036,0x7F030083,0x7F0300AE,0x7F0300DD,0x7F030170,0x7F0301C0 }
+			// aapt resource value: { 0x7F030029,0x7F03002A,0x7F030036,0x7F030084,0x7F0300AF,0x7F0300DE,0x7F030171,0x7F0301C1 }
 			public static int[] DrawerArrowToggle = new int[] {
 					2130903081,
 					2130903082,
 					2130903094,
-					2130903171,
-					2130903214,
-					2130903261,
-					2130903408,
-					2130903488};
+					2130903172,
+					2130903215,
+					2130903262,
+					2130903409,
+					2130903489};
 			
 			// aapt resource value: 0
 			public const int DrawerArrowToggle_arrowHeadLength = 0;
@@ -13444,21 +13463,21 @@ namespace Playground.Droid
 			// aapt resource value: 7
 			public const int DrawerArrowToggle_thickness = 7;
 			
-			// aapt resource value: { 0x7F030034,0x7F030035,0x7F03003D,0x7F0300B5,0x7F0300C8,0x7F0300C9,0x7F0300E4,0x7F0300EC,0x7F03012A,0x7F030151,0x7F03015B,0x7F030167,0x7F0301DE }
+			// aapt resource value: { 0x7F030034,0x7F030035,0x7F03003D,0x7F0300B6,0x7F0300C9,0x7F0300CA,0x7F0300E5,0x7F0300ED,0x7F03012B,0x7F030152,0x7F03015C,0x7F030168,0x7F0301DF }
 			public static int[] FloatingActionButton = new int[] {
 					2130903092,
 					2130903093,
 					2130903101,
-					2130903221,
-					2130903240,
+					2130903222,
 					2130903241,
-					2130903268,
-					2130903276,
-					2130903338,
-					2130903377,
-					2130903387,
-					2130903399,
-					2130903518};
+					2130903242,
+					2130903269,
+					2130903277,
+					2130903339,
+					2130903378,
+					2130903388,
+					2130903400,
+					2130903519};
 			
 			// aapt resource value: 0
 			public const int FloatingActionButton_backgroundTint = 0;
@@ -13506,10 +13525,10 @@ namespace Playground.Droid
 			// aapt resource value: 12
 			public const int FloatingActionButton_useCompatPadding = 12;
 			
-			// aapt resource value: { 0x7F030102,0x7F030118 }
+			// aapt resource value: { 0x7F030103,0x7F030119 }
 			public static int[] FlowLayout = new int[] {
-					2130903298,
-					2130903320};
+					2130903299,
+					2130903321};
 			
 			// aapt resource value: 0
 			public const int FlowLayout_itemSpacing = 0;
@@ -13517,27 +13536,27 @@ namespace Playground.Droid
 			// aapt resource value: 1
 			public const int FlowLayout_lineSpacing = 1;
 			
-			// aapt resource value: { 0x7F0300D3,0x7F0300D4,0x7F0300D5,0x7F0300D6,0x7F0300D7,0x7F0300D8 }
+			// aapt resource value: { 0x7F0300D4,0x7F0300D5,0x7F0300D6,0x7F0300D7,0x7F0300D8,0x7F0300D9 }
 			public static int[] FontFamily = new int[] {
-					2130903251,
 					2130903252,
 					2130903253,
 					2130903254,
 					2130903255,
-					2130903256};
+					2130903256,
+					2130903257};
 			
-			// aapt resource value: { 0x1010532,0x1010533,0x101053F,0x101056F,0x1010570,0x7F0300D1,0x7F0300D9,0x7F0300DA,0x7F0300DB,0x7F0301DD }
+			// aapt resource value: { 0x1010532,0x1010533,0x101053F,0x101056F,0x1010570,0x7F0300D2,0x7F0300DA,0x7F0300DB,0x7F0300DC,0x7F0301DE }
 			public static int[] FontFamilyFont = new int[] {
 					16844082,
 					16844083,
 					16844095,
 					16844143,
 					16844144,
-					2130903249,
-					2130903257,
+					2130903250,
 					2130903258,
 					2130903259,
-					2130903517};
+					2130903260,
+					2130903518};
 			
 			// aapt resource value: 0
 			public const int FontFamilyFont_android_font = 0;
@@ -13587,11 +13606,11 @@ namespace Playground.Droid
 			// aapt resource value: 5
 			public const int FontFamily_fontProviderQuery = 5;
 			
-			// aapt resource value: { 0x1010109,0x1010200,0x7F0300DC }
+			// aapt resource value: { 0x1010109,0x1010200,0x7F0300DD }
 			public static int[] ForegroundLinearLayout = new int[] {
 					16843017,
 					16843264,
-					2130903260};
+					2130903261};
 			
 			// aapt resource value: 0
 			public const int ForegroundLinearLayout_android_foreground = 0;
@@ -13664,17 +13683,24 @@ namespace Playground.Droid
 			// aapt resource value: 2
 			public const int GradientColor_android_type = 2;
 			
-			// aapt resource value: { 0x10100AF,0x10100C4,0x1010126,0x1010127,0x1010128,0x7F0300AA,0x7F0300AC,0x7F03012B,0x7F030166 }
+			// aapt resource value: { 0x7F030083 }
+			public static int[] ItemsViewRendererTheme = new int[] {
+					2130903171};
+			
+			// aapt resource value: 0
+			public const int ItemsViewRendererTheme_collectionViewStyle = 0;
+			
+			// aapt resource value: { 0x10100AF,0x10100C4,0x1010126,0x1010127,0x1010128,0x7F0300AB,0x7F0300AD,0x7F03012C,0x7F030167 }
 			public static int[] LinearLayoutCompat = new int[] {
 					16842927,
 					16842948,
 					16843046,
 					16843047,
 					16843048,
-					2130903210,
-					2130903212,
-					2130903339,
-					2130903398};
+					2130903211,
+					2130903213,
+					2130903340,
+					2130903399};
 			
 			// aapt resource value: 2
 			public const int LinearLayoutCompat_android_baselineAligned = 2;
@@ -13733,7 +13759,7 @@ namespace Playground.Droid
 			// aapt resource value: 1
 			public const int ListPopupWindow_android_dropDownVerticalOffset = 1;
 			
-			// aapt resource value: { 0x10101B7,0x10101B8,0x10101B9,0x10101BA,0x7F030034,0x7F030035,0x7F03009F,0x7F0300ED,0x7F0300EF,0x7F0300F0,0x7F0300F1,0x7F0300F3,0x7F0300F4,0x7F03015B,0x7F03017D,0x7F03017E }
+			// aapt resource value: { 0x10101B7,0x10101B8,0x10101B9,0x10101BA,0x7F030034,0x7F030035,0x7F0300A0,0x7F0300EE,0x7F0300F0,0x7F0300F1,0x7F0300F2,0x7F0300F4,0x7F0300F5,0x7F03015C,0x7F03017E,0x7F03017F }
 			public static int[] MaterialButton = new int[] {
 					16843191,
 					16843192,
@@ -13741,16 +13767,16 @@ namespace Playground.Droid
 					16843194,
 					2130903092,
 					2130903093,
-					2130903199,
-					2130903277,
-					2130903279,
+					2130903200,
+					2130903278,
 					2130903280,
 					2130903281,
-					2130903283,
+					2130903282,
 					2130903284,
-					2130903387,
-					2130903421,
-					2130903422};
+					2130903285,
+					2130903388,
+					2130903422,
+					2130903423};
 			
 			// aapt resource value: 3
 			public const int MaterialButton_android_insetBottom = 3;
@@ -13800,10 +13826,10 @@ namespace Playground.Droid
 			// aapt resource value: 15
 			public const int MaterialButton_strokeWidth = 15;
 			
-			// aapt resource value: { 0x7F03017D,0x7F03017E }
+			// aapt resource value: { 0x7F03017E,0x7F03017F }
 			public static int[] MaterialCardView = new int[] {
-					2130903421,
-					2130903422};
+					2130903422,
+					2130903423};
 			
 			// aapt resource value: 0
 			public const int MaterialCardView_strokeColor = 0;
@@ -13811,27 +13837,26 @@ namespace Playground.Droid
 			// aapt resource value: 1
 			public const int MaterialCardView_strokeWidth = 1;
 			
-			// aapt resource value: { 0x7F030041,0x7F030042,0x7F030068,0x7F030072,0x7F030076,0x7F030084,0x7F030085,0x7F03008B,0x7F03008C,0x7F03008D,0x7F0300B4,0x7F0300D0,0x7F030126,0x7F030127,0x7F03013E,0x7F03015D,0x7F03016D,0x7F0301A0,0x7F0301A5,0x7F0301A6,0x7F0301A7,0x7F0301A8,0x7F0301A9,0x7F0301AA,0x7F0301AB,0x7F0301AC,0x7F0301AD,0x7F0301AE,0x7F0301B3,0x7F0301B8,0x7F0301B9,0x7F0301BD }
+			// aapt resource value: { 0x7F030041,0x7F030042,0x7F030068,0x7F030072,0x7F030076,0x7F030085,0x7F030086,0x7F03008C,0x7F03008D,0x7F03008E,0x7F0300B5,0x7F0300D1,0x7F030127,0x7F030128,0x7F03013F,0x7F03015E,0x7F03016E,0x7F0301A1,0x7F0301A6,0x7F0301A7,0x7F0301A8,0x7F0301A9,0x7F0301AA,0x7F0301AB,0x7F0301AC,0x7F0301AD,0x7F0301AE,0x7F0301AF,0x7F0301B4,0x7F0301B9,0x7F0301BA,0x7F0301BE }
 			public static int[] MaterialComponentsTheme = new int[] {
 					2130903105,
 					2130903106,
 					2130903144,
 					2130903154,
 					2130903158,
-					2130903172,
 					2130903173,
-					2130903179,
+					2130903174,
 					2130903180,
 					2130903181,
-					2130903220,
-					2130903248,
-					2130903334,
+					2130903182,
+					2130903221,
+					2130903249,
 					2130903335,
-					2130903358,
-					2130903389,
-					2130903405,
-					2130903456,
-					2130903461,
+					2130903336,
+					2130903359,
+					2130903390,
+					2130903406,
+					2130903457,
 					2130903462,
 					2130903463,
 					2130903464,
@@ -13841,10 +13866,11 @@ namespace Playground.Droid
 					2130903468,
 					2130903469,
 					2130903470,
-					2130903475,
-					2130903480,
+					2130903471,
+					2130903476,
 					2130903481,
-					2130903485};
+					2130903482,
+					2130903486};
 			
 			// aapt resource value: 0
 			public const int MaterialComponentsTheme_bottomSheetDialogTheme = 0;
@@ -13942,12 +13968,12 @@ namespace Playground.Droid
 			// aapt resource value: 31
 			public const int MaterialComponentsTheme_textInputStyle = 31;
 			
-			// aapt resource value: { 0x101013F,0x1010140,0x7F0300C3,0x7F03012E }
+			// aapt resource value: { 0x101013F,0x1010140,0x7F0300C4,0x7F03012F }
 			public static int[] MediaRouteButton = new int[] {
 					16843071,
 					16843072,
-					2130903235,
-					2130903342};
+					2130903236,
+					2130903343};
 			
 			// aapt resource value: 1
 			public const int MediaRouteButton_android_minHeight = 1;
@@ -13988,7 +14014,7 @@ namespace Playground.Droid
 			// aapt resource value: 2
 			public const int MenuGroup_android_visible = 2;
 			
-			// aapt resource value: { 0x1010002,0x101000E,0x10100D0,0x1010106,0x1010194,0x10101DE,0x10101DF,0x10101E1,0x10101E2,0x10101E3,0x10101E4,0x10101E5,0x101026F,0x7F03000D,0x7F03001F,0x7F030020,0x7F030028,0x7F030090,0x7F0300F3,0x7F0300F4,0x7F03013F,0x7F030165,0x7F0301D9 }
+			// aapt resource value: { 0x1010002,0x101000E,0x10100D0,0x1010106,0x1010194,0x10101DE,0x10101DF,0x10101E1,0x10101E2,0x10101E3,0x10101E4,0x10101E5,0x101026F,0x7F03000D,0x7F03001F,0x7F030020,0x7F030028,0x7F030091,0x7F0300F4,0x7F0300F5,0x7F030140,0x7F030166,0x7F0301DA }
 			public static int[] MenuItem = new int[] {
 					16842754,
 					16842766,
@@ -14007,12 +14033,12 @@ namespace Playground.Droid
 					2130903071,
 					2130903072,
 					2130903080,
-					2130903184,
-					2130903283,
+					2130903185,
 					2130903284,
-					2130903359,
-					2130903397,
-					2130903513};
+					2130903285,
+					2130903360,
+					2130903398,
+					2130903514};
 			
 			// aapt resource value: 13
 			public const int MenuItem_actionLayout = 13;
@@ -14083,7 +14109,7 @@ namespace Playground.Droid
 			// aapt resource value: 22
 			public const int MenuItem_tooltipText = 22;
 			
-			// aapt resource value: { 0x10100AE,0x101012C,0x101012D,0x101012E,0x101012F,0x1010130,0x1010131,0x7F030150,0x7F03017F }
+			// aapt resource value: { 0x10100AE,0x101012C,0x101012D,0x101012E,0x101012F,0x1010130,0x1010131,0x7F030151,0x7F030180 }
 			public static int[] MenuView = new int[] {
 					16842926,
 					16843052,
@@ -14092,8 +14118,8 @@ namespace Playground.Droid
 					16843055,
 					16843056,
 					16843057,
-					2130903376,
-					2130903423};
+					2130903377,
+					2130903424};
 			
 			// aapt resource value: 4
 			public const int MenuView_android_headerBackground = 4;
@@ -14122,20 +14148,20 @@ namespace Playground.Droid
 			// aapt resource value: 8
 			public const int MenuView_subMenuArrow = 8;
 			
-			// aapt resource value: { 0x10100D4,0x10100DD,0x101011F,0x7F0300B5,0x7F0300DF,0x7F0300FB,0x7F0300FC,0x7F0300FE,0x7F030100,0x7F030103,0x7F030106,0x7F030139 }
+			// aapt resource value: { 0x10100D4,0x10100DD,0x101011F,0x7F0300B6,0x7F0300E0,0x7F0300FC,0x7F0300FD,0x7F0300FF,0x7F030101,0x7F030104,0x7F030107,0x7F03013A }
 			public static int[] NavigationView = new int[] {
 					16842964,
 					16842973,
 					16843039,
-					2130903221,
-					2130903263,
-					2130903291,
+					2130903222,
+					2130903264,
 					2130903292,
-					2130903294,
-					2130903296,
-					2130903299,
-					2130903302,
-					2130903353};
+					2130903293,
+					2130903295,
+					2130903297,
+					2130903300,
+					2130903303,
+					2130903354};
 			
 			// aapt resource value: 0
 			public const int NavigationView_android_background = 0;
@@ -14173,15 +14199,15 @@ namespace Playground.Droid
 			// aapt resource value: 11
 			public const int NavigationView_menu = 11;
 			
-			// aapt resource value: { 0x1010176,0x10102C9,0x7F030140 }
+			// aapt resource value: { 0x1010176,0x10102C9,0x7F030141 }
 			public static int[] PopupWindow = new int[] {
 					16843126,
 					16843465,
-					2130903360};
+					2130903361};
 			
-			// aapt resource value: { 0x7F030176 }
+			// aapt resource value: { 0x7F030177 }
 			public static int[] PopupWindowBackgroundState = new int[] {
-					2130903414};
+					2130903415};
 			
 			// aapt resource value: 0
 			public const int PopupWindowBackgroundState_state_above_anchor = 0;
@@ -14195,10 +14221,10 @@ namespace Playground.Droid
 			// aapt resource value: 2
 			public const int PopupWindow_overlapAnchor = 2;
 			
-			// aapt resource value: { 0x7F030141,0x7F030144 }
+			// aapt resource value: { 0x7F030142,0x7F030145 }
 			public static int[] RecycleListView = new int[] {
-					2130903361,
-					2130903364};
+					2130903362,
+					2130903365};
 			
 			// aapt resource value: 0
 			public const int RecycleListView_paddingBottomNoButtons = 0;
@@ -14206,19 +14232,19 @@ namespace Playground.Droid
 			// aapt resource value: 1
 			public const int RecycleListView_paddingTopNoTitle = 1;
 			
-			// aapt resource value: { 0x10100C4,0x10100F1,0x7F0300CA,0x7F0300CB,0x7F0300CC,0x7F0300CD,0x7F0300CE,0x7F03010B,0x7F03015A,0x7F03016F,0x7F030175 }
+			// aapt resource value: { 0x10100C4,0x10100F1,0x7F0300CB,0x7F0300CC,0x7F0300CD,0x7F0300CE,0x7F0300CF,0x7F03010C,0x7F03015B,0x7F030170,0x7F030176 }
 			public static int[] RecyclerView = new int[] {
 					16842948,
 					16842993,
-					2130903242,
 					2130903243,
 					2130903244,
 					2130903245,
 					2130903246,
-					2130903307,
-					2130903386,
-					2130903407,
-					2130903413};
+					2130903247,
+					2130903308,
+					2130903387,
+					2130903408,
+					2130903414};
 			
 			// aapt resource value: 1
 			public const int RecyclerView_android_descendantFocusability = 1;
@@ -14253,9 +14279,9 @@ namespace Playground.Droid
 			// aapt resource value: 10
 			public const int RecyclerView_stackFromEnd = 10;
 			
-			// aapt resource value: { 0x7F0300F9 }
+			// aapt resource value: { 0x7F0300FA }
 			public static int[] ScrimInsetsFrameLayout = new int[] {
-					2130903289};
+					2130903290};
 			
 			// aapt resource value: 0
 			public const int ScrimInsetsFrameLayout_insetForeground = 0;
@@ -14267,25 +14293,25 @@ namespace Playground.Droid
 			// aapt resource value: 0
 			public const int ScrollingViewBehavior_Layout_behavior_overlapTop = 0;
 			
-			// aapt resource value: { 0x10100DA,0x101011F,0x1010220,0x1010264,0x7F030077,0x7F03008F,0x7F0300A5,0x7F0300DE,0x7F0300F5,0x7F03010A,0x7F030154,0x7F030155,0x7F03015F,0x7F030160,0x7F030180,0x7F030185,0x7F0301E0 }
+			// aapt resource value: { 0x10100DA,0x101011F,0x1010220,0x1010264,0x7F030077,0x7F030090,0x7F0300A6,0x7F0300DF,0x7F0300F6,0x7F03010B,0x7F030155,0x7F030156,0x7F030160,0x7F030161,0x7F030181,0x7F030186,0x7F0301E1 }
 			public static int[] SearchView = new int[] {
 					16842970,
 					16843039,
 					16843296,
 					16843364,
 					2130903159,
-					2130903183,
-					2130903205,
-					2130903262,
-					2130903285,
-					2130903306,
-					2130903380,
+					2130903184,
+					2130903206,
+					2130903263,
+					2130903286,
+					2130903307,
 					2130903381,
-					2130903391,
+					2130903382,
 					2130903392,
-					2130903424,
-					2130903429,
-					2130903520};
+					2130903393,
+					2130903425,
+					2130903430,
+					2130903521};
 			
 			// aapt resource value: 0
 			public const int SearchView_android_focusable = 0;
@@ -14338,16 +14364,16 @@ namespace Playground.Droid
 			// aapt resource value: 16
 			public const int SearchView_voiceIcon = 16;
 			
-			// aapt resource value: { 0x7F03016D,0x7F03016E }
+			// aapt resource value: { 0x7F03016E,0x7F03016F }
 			public static int[] Snackbar = new int[] {
-					2130903405,
-					2130903406};
+					2130903406,
+					2130903407};
 			
-			// aapt resource value: { 0x101011F,0x7F0300B5,0x7F030128 }
+			// aapt resource value: { 0x101011F,0x7F0300B6,0x7F030129 }
 			public static int[] SnackbarLayout = new int[] {
 					16843039,
-					2130903221,
-					2130903336};
+					2130903222,
+					2130903337};
 			
 			// aapt resource value: 0
 			public const int SnackbarLayout_android_maxWidth = 0;
@@ -14364,13 +14390,13 @@ namespace Playground.Droid
 			// aapt resource value: 1
 			public const int Snackbar_snackbarStyle = 1;
 			
-			// aapt resource value: { 0x10100B2,0x1010176,0x101017B,0x1010262,0x7F03014E }
+			// aapt resource value: { 0x10100B2,0x1010176,0x101017B,0x1010262,0x7F03014F }
 			public static int[] Spinner = new int[] {
 					16842930,
 					16843126,
 					16843131,
 					16843362,
-					2130903374};
+					2130903375};
 			
 			// aapt resource value: 3
 			public const int Spinner_android_dropDownWidth = 3;
@@ -14421,22 +14447,22 @@ namespace Playground.Droid
 			// aapt resource value: 1
 			public const int StateListDrawable_android_visible = 1;
 			
-			// aapt resource value: { 0x1010124,0x1010125,0x1010142,0x7F030168,0x7F030173,0x7F030186,0x7F030187,0x7F030189,0x7F0301C1,0x7F0301C2,0x7F0301C3,0x7F0301DA,0x7F0301DB,0x7F0301DC }
+			// aapt resource value: { 0x1010124,0x1010125,0x1010142,0x7F030169,0x7F030174,0x7F030187,0x7F030188,0x7F03018A,0x7F0301C2,0x7F0301C3,0x7F0301C4,0x7F0301DB,0x7F0301DC,0x7F0301DD }
 			public static int[] SwitchCompat = new int[] {
 					16843044,
 					16843045,
 					16843074,
-					2130903400,
-					2130903411,
-					2130903430,
+					2130903401,
+					2130903412,
 					2130903431,
-					2130903433,
-					2130903489,
+					2130903432,
+					2130903434,
 					2130903490,
 					2130903491,
-					2130903514,
+					2130903492,
 					2130903515,
-					2130903516};
+					2130903516,
+					2130903517};
 			
 			// aapt resource value: 1
 			public const int SwitchCompat_android_textOff = 1;
@@ -14495,9 +14521,8 @@ namespace Playground.Droid
 			// aapt resource value: 2
 			public const int TabItem_android_text = 2;
 			
-			// aapt resource value: { 0x7F03018A,0x7F03018B,0x7F03018C,0x7F03018D,0x7F03018E,0x7F03018F,0x7F030190,0x7F030191,0x7F030192,0x7F030193,0x7F030194,0x7F030195,0x7F030196,0x7F030197,0x7F030198,0x7F030199,0x7F03019A,0x7F03019B,0x7F03019C,0x7F03019D,0x7F03019E,0x7F03019F,0x7F0301A1,0x7F0301A2,0x7F0301A3 }
+			// aapt resource value: { 0x7F03018B,0x7F03018C,0x7F03018D,0x7F03018E,0x7F03018F,0x7F030190,0x7F030191,0x7F030192,0x7F030193,0x7F030194,0x7F030195,0x7F030196,0x7F030197,0x7F030198,0x7F030199,0x7F03019A,0x7F03019B,0x7F03019C,0x7F03019D,0x7F03019E,0x7F03019F,0x7F0301A0,0x7F0301A2,0x7F0301A3,0x7F0301A4 }
 			public static int[] TabLayout = new int[] {
-					2130903434,
 					2130903435,
 					2130903436,
 					2130903437,
@@ -14519,9 +14544,10 @@ namespace Playground.Droid
 					2130903453,
 					2130903454,
 					2130903455,
-					2130903457,
+					2130903456,
 					2130903458,
-					2130903459};
+					2130903459,
+					2130903460};
 			
 			// aapt resource value: 0
 			public const int TabLayout_tabBackground = 0;
@@ -14598,7 +14624,7 @@ namespace Playground.Droid
 			// aapt resource value: 24
 			public const int TabLayout_tabUnboundedRipple = 24;
 			
-			// aapt resource value: { 0x1010095,0x1010096,0x1010097,0x1010098,0x101009A,0x101009B,0x1010161,0x1010162,0x1010163,0x1010164,0x10103AC,0x7F0300D2,0x7F0301A4 }
+			// aapt resource value: { 0x1010095,0x1010096,0x1010097,0x1010098,0x101009A,0x101009B,0x1010161,0x1010162,0x1010163,0x1010164,0x10103AC,0x7F0300D3,0x7F0301A5 }
 			public static int[] TextAppearance = new int[] {
 					16842901,
 					16842902,
@@ -14611,8 +14637,8 @@ namespace Playground.Droid
 					16843107,
 					16843108,
 					16843692,
-					2130903250,
-					2130903460};
+					2130903251,
+					2130903461};
 			
 			// aapt resource value: 10
 			public const int TextAppearance_android_fontFamily = 10;
@@ -14653,7 +14679,7 @@ namespace Playground.Droid
 			// aapt resource value: 12
 			public const int TextAppearance_textAllCaps = 12;
 			
-			// aapt resource value: { 0x101009A,0x1010150,0x7F030043,0x7F030044,0x7F030045,0x7F030046,0x7F030047,0x7F030048,0x7F030049,0x7F03004A,0x7F03004B,0x7F0300A0,0x7F0300A1,0x7F0300A2,0x7F0300A3,0x7F0300B8,0x7F0300B9,0x7F0300E1,0x7F0300E2,0x7F0300E3,0x7F0300E7,0x7F0300E8,0x7F0300E9,0x7F030148,0x7F030149,0x7F03014A,0x7F03014B,0x7F03014C }
+			// aapt resource value: { 0x101009A,0x1010150,0x7F030043,0x7F030044,0x7F030045,0x7F030046,0x7F030047,0x7F030048,0x7F030049,0x7F03004A,0x7F03004B,0x7F0300A1,0x7F0300A2,0x7F0300A3,0x7F0300A4,0x7F0300B9,0x7F0300BA,0x7F0300E2,0x7F0300E3,0x7F0300E4,0x7F0300E8,0x7F0300E9,0x7F0300EA,0x7F030149,0x7F03014A,0x7F03014B,0x7F03014C,0x7F03014D }
 			public static int[] TextInputLayout = new int[] {
 					16842906,
 					16843088,
@@ -14666,23 +14692,23 @@ namespace Playground.Droid
 					2130903113,
 					2130903114,
 					2130903115,
-					2130903200,
 					2130903201,
 					2130903202,
 					2130903203,
-					2130903224,
+					2130903204,
 					2130903225,
-					2130903265,
+					2130903226,
 					2130903266,
 					2130903267,
-					2130903271,
+					2130903268,
 					2130903272,
 					2130903273,
-					2130903368,
+					2130903274,
 					2130903369,
 					2130903370,
 					2130903371,
-					2130903372};
+					2130903372,
+					2130903373};
 			
 			// aapt resource value: 1
 			public const int TextInputLayout_android_hint = 1;
@@ -14768,11 +14794,11 @@ namespace Playground.Droid
 			// aapt resource value: 27
 			public const int TextInputLayout_passwordToggleTintMode = 27;
 			
-			// aapt resource value: { 0x1010034,0x7F0300B6,0x7F0300B7 }
+			// aapt resource value: { 0x1010034,0x7F0300B7,0x7F0300B8 }
 			public static int[] ThemeEnforcement = new int[] {
 					16842804,
-					2130903222,
-					2130903223};
+					2130903223,
+					2130903224};
 			
 			// aapt resource value: 0
 			public const int ThemeEnforcement_android_textAppearance = 0;
@@ -14783,37 +14809,37 @@ namespace Playground.Droid
 			// aapt resource value: 2
 			public const int ThemeEnforcement_enforceTextAppearance = 2;
 			
-			// aapt resource value: { 0x10100AF,0x1010140,0x7F030051,0x7F03007F,0x7F030080,0x7F030091,0x7F030092,0x7F030093,0x7F030094,0x7F030095,0x7F030096,0x7F030124,0x7F030125,0x7F030129,0x7F03013B,0x7F03013C,0x7F03014E,0x7F030181,0x7F030182,0x7F030183,0x7F0301C9,0x7F0301CB,0x7F0301CC,0x7F0301CD,0x7F0301CE,0x7F0301CF,0x7F0301D0,0x7F0301D1,0x7F0301D2 }
+			// aapt resource value: { 0x10100AF,0x1010140,0x7F030051,0x7F03007F,0x7F030080,0x7F030092,0x7F030093,0x7F030094,0x7F030095,0x7F030096,0x7F030097,0x7F030125,0x7F030126,0x7F03012A,0x7F03013C,0x7F03013D,0x7F03014F,0x7F030182,0x7F030183,0x7F030184,0x7F0301CA,0x7F0301CC,0x7F0301CD,0x7F0301CE,0x7F0301CF,0x7F0301D0,0x7F0301D1,0x7F0301D2,0x7F0301D3 }
 			public static int[] Toolbar = new int[] {
 					16842927,
 					16843072,
 					2130903121,
 					2130903167,
 					2130903168,
-					2130903185,
 					2130903186,
 					2130903187,
 					2130903188,
 					2130903189,
 					2130903190,
-					2130903332,
+					2130903191,
 					2130903333,
-					2130903337,
-					2130903355,
+					2130903334,
+					2130903338,
 					2130903356,
-					2130903374,
-					2130903425,
+					2130903357,
+					2130903375,
 					2130903426,
 					2130903427,
-					2130903497,
-					2130903499,
+					2130903428,
+					2130903498,
 					2130903500,
 					2130903501,
 					2130903502,
 					2130903503,
 					2130903504,
 					2130903505,
-					2130903506};
+					2130903506,
+					2130903507};
 			
 			// aapt resource value: 0
 			public const int Toolbar_android_gravity = 0;
@@ -14902,13 +14928,13 @@ namespace Playground.Droid
 			// aapt resource value: 28
 			public const int Toolbar_titleTextColor = 28;
 			
-			// aapt resource value: { 0x1010000,0x10100DA,0x7F030142,0x7F030143,0x7F0301BF }
+			// aapt resource value: { 0x1010000,0x10100DA,0x7F030143,0x7F030144,0x7F0301C0 }
 			public static int[] View = new int[] {
 					16842752,
 					16842970,
-					2130903362,
 					2130903363,
-					2130903487};
+					2130903364,
+					2130903488};
 			
 			// aapt resource value: { 0x10100D4,0x7F030034,0x7F030035 }
 			public static int[] ViewBackgroundHelper = new int[] {

--- a/Playground/Playground.Data/Playground.Data.csproj
+++ b/Playground/Playground.Data/Playground.Data.csproj
@@ -81,7 +81,7 @@
   <ItemGroup>
     <PackageReference Include="LiteDB" Version="4.1.4" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
-    <PackageReference Include="Xamarin.Forms" Version="4.6.0.800" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1269" />
   </ItemGroup>
 
 </Project>

--- a/Playground/Playground.iOS/Playground.iOS.csproj
+++ b/Playground/Playground.iOS/Playground.iOS.csproj
@@ -120,7 +120,7 @@
     <Reference Include="System.Numerics.Vectors" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.6.0.800" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1269" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/Playground/Playground/Playground.csproj
+++ b/Playground/Playground/Playground.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Bogus" Version="29.0.2" />
     <PackageReference Include="SkiaSharp.Views.Forms" Version="1.68.1.1" />
-    <PackageReference Include="Xamarin.Forms" Version="4.6.0.800" />  
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1269" />  
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
   </ItemGroup>
 

--- a/PlaygroundLite/PlaygroundLite/ViewModels/GradientViewModel.cs
+++ b/PlaygroundLite/PlaygroundLite/ViewModels/GradientViewModel.cs
@@ -60,12 +60,12 @@ namespace PlaygroundLite.ViewModels
         private void UpdateLength()
         {
             foreach (var stop in Gradient.Stops)
-                stop.Offset = -1;
+                stop.Offset = Offset.Empty;
 
             Gradient.Measure(0, 0);
 
             foreach (var stop in Gradient.Stops)
-                stop.Offset = stop.RenderOffset * (float)Length;
+                stop.Offset = Offset.Prop(stop.RenderOffset * (float)Length);
         }
     }
 }


### PR DESCRIPTION
XForms 4.8 introduced Brushes and support for background property... which is the same as MG uses. Before we were always adding new property to styles Registrar, now we have to check if it already exists.

Fixes #107 