### PR TITLE
Add Magic Button Control

### DIFF
--- a/MagicGradients.sln
+++ b/MagicGradients.sln
@@ -79,7 +79,6 @@ Global
 		{477F1169-FF99-43ED-9F59-6E9145975C83}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{477F1169-FF99-43ED-9F59-6E9145975C83}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 		{477F1169-FF99-43ED-9F59-6E9145975C83}.Release|iPhoneSimulator.Deploy.0 = Release|Any CPU
-		{067E1502-3887-46BF-8253-84D4AB45E1B6}.Debug|Any CPU.ActiveCfg = Debug|iPhone
 		{067E1502-3887-46BF-8253-84D4AB45E1B6}.Debug|iPhone.ActiveCfg = Debug|iPhone
 		{067E1502-3887-46BF-8253-84D4AB45E1B6}.Debug|iPhone.Build.0 = Debug|iPhone
 		{067E1502-3887-46BF-8253-84D4AB45E1B6}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
@@ -89,7 +88,9 @@ Global
 		{067E1502-3887-46BF-8253-84D4AB45E1B6}.Release|iPhone.Build.0 = Release|iPhone
 		{067E1502-3887-46BF-8253-84D4AB45E1B6}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
 		{067E1502-3887-46BF-8253-84D4AB45E1B6}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
-		{067E1502-3887-46BF-8253-84D4AB45E1B6}.Debug|Any CPU.Build.0 = Debug|iPhone
+		{067E1502-3887-46BF-8253-84D4AB45E1B6}.Debug|Any CPU.ActiveCfg = Debug|iPhoneSimulator
+		{067E1502-3887-46BF-8253-84D4AB45E1B6}.Debug|Any CPU.Build.0 = Debug|iPhoneSimulator
+		{067E1502-3887-46BF-8253-84D4AB45E1B6}.Debug|Any CPU.Deploy.0 = Debug|iPhoneSimulator
 		{05EBBB6C-3B45-498C-B95E-0755F9FCA6A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{05EBBB6C-3B45-498C-B95E-0755F9FCA6A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{05EBBB6C-3B45-498C-B95E-0755F9FCA6A0}.Debug|iPhone.ActiveCfg = Debug|Any CPU
@@ -156,7 +157,6 @@ Global
 		{F2A325A6-F404-44A3-B051-C6762779F853}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{F2A325A6-F404-44A3-B051-C6762779F853}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 		{F2A325A6-F404-44A3-B051-C6762779F853}.Release|iPhoneSimulator.Deploy.0 = Release|Any CPU
-		{86EEF0B4-5497-4DEA-AFBA-08702F4C9CC3}.Debug|Any CPU.ActiveCfg = Debug|iPhone
 		{86EEF0B4-5497-4DEA-AFBA-08702F4C9CC3}.Debug|iPhone.ActiveCfg = Debug|iPhone
 		{86EEF0B4-5497-4DEA-AFBA-08702F4C9CC3}.Debug|iPhone.Build.0 = Debug|iPhone
 		{86EEF0B4-5497-4DEA-AFBA-08702F4C9CC3}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
@@ -166,7 +166,9 @@ Global
 		{86EEF0B4-5497-4DEA-AFBA-08702F4C9CC3}.Release|iPhone.Build.0 = Release|iPhone
 		{86EEF0B4-5497-4DEA-AFBA-08702F4C9CC3}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
 		{86EEF0B4-5497-4DEA-AFBA-08702F4C9CC3}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
-		{86EEF0B4-5497-4DEA-AFBA-08702F4C9CC3}.Debug|Any CPU.Build.0 = Debug|iPhone
+		{86EEF0B4-5497-4DEA-AFBA-08702F4C9CC3}.Debug|Any CPU.ActiveCfg = Debug|iPhoneSimulator
+		{86EEF0B4-5497-4DEA-AFBA-08702F4C9CC3}.Debug|Any CPU.Build.0 = Debug|iPhoneSimulator
+		{86EEF0B4-5497-4DEA-AFBA-08702F4C9CC3}.Debug|Any CPU.Deploy.0 = Debug|iPhoneSimulator
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MagicGradients/Controls/MagicButton.xaml
+++ b/MagicGradients/Controls/MagicButton.xaml
@@ -1,40 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<ContentView
+<TemplatedView 
     x:Class="MagicGradients.Controls.MagicButton"
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:magic="clr-namespace:MagicGradients;assembly=MagicGradients">
-    <ContentView.ControlTemplate>
+    <TemplatedView.ControlTemplate>
         <ControlTemplate>
-            <Frame
-                x:Name="TopFrame"
-                Margin="0"
-                Padding="0"
-                HasShadow="False"
-                IsClippedToBounds="True">
+            <Frame x:Name="BorderFrame" Margin="0" Padding="0" HasShadow="False" IsClippedToBounds="True">
                 <Grid>
-                    <magic:GradientView x:Name="GradientView" Margin="-2" />
-                    <ContentPresenter />
-                    <Button
-                        x:Name="ActionButton"
-                        BackgroundColor="Transparent"
-                        Visual="Default" />
+                    <magic:GradientView x:Name="GradientView" />
+                    <ContentPresenter x:Name="ContentPresenter">
+                        <ContentPresenter.GestureRecognizers>
+                            <TapGestureRecognizer x:Name="TapRecognizer" />
+                        </ContentPresenter.GestureRecognizers>
+                    </ContentPresenter>
                 </Grid>
             </Frame>
         </ControlTemplate>
-    </ContentView.ControlTemplate>
-    <!--<Frame
-        x:Name="TopFrame"
-        Margin="0"
-        Padding="0"
-        HasShadow="False"
-        IsClippedToBounds="True">
-        <Grid>
-            <magic:GradientView x:Name="GradientView" Margin="-2" />
-            <Button
-                x:Name="ActionButton"
-                BackgroundColor="Transparent"
-                Visual="Default" />
-        </Grid>
-    </Frame>-->
-</ContentView>
+    </TemplatedView.ControlTemplate>
+</TemplatedView>

--- a/MagicGradients/Controls/MagicButton.xaml
+++ b/MagicGradients/Controls/MagicButton.xaml
@@ -1,20 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<ContentView
+<Frame
     x:Class="MagicGradients.Controls.MagicButton"
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:magic="clr-namespace:MagicGradients;assembly=MagicGradients">
-    <ContentView.Content>
-        <Frame
-            x:Name="TopFrame"
-            Margin="0"
-            Padding="0"
-            IsClippedToBounds="True"
-            HasShadow="False">
-            <Grid>
-                <magic:GradientView x:Name="GradientView" Margin="-2" />
-                <Button x:Name="ActionButton" BackgroundColor="Transparent" Visual="Default" />
-            </Grid>
-        </Frame>
-    </ContentView.Content>
-</ContentView>
+    xmlns:magic="clr-namespace:MagicGradients;assembly=MagicGradients"
+    x:Name="TopFrame"
+    Margin="0"
+    Padding="0"
+    IsClippedToBounds="True"
+    HasShadow="False">
+    <Grid>
+        <magic:GradientView x:Name="GradientView" Margin="-2" />
+        <Button x:Name="ActionButton" BackgroundColor="Transparent" Visual="Default" />
+    </Grid>
+</Frame>

--- a/MagicGradients/Controls/MagicButton.xaml
+++ b/MagicGradients/Controls/MagicButton.xaml
@@ -1,16 +1,40 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<Frame
+<ContentView
     x:Class="MagicGradients.Controls.MagicButton"
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:magic="clr-namespace:MagicGradients;assembly=MagicGradients"
-    x:Name="TopFrame"
-    Margin="0"
-    Padding="0"
-    IsClippedToBounds="True"
-    HasShadow="False">
-    <Grid>
-        <magic:GradientView x:Name="GradientView" Margin="-2" />
-        <Button x:Name="ActionButton" BackgroundColor="Transparent" Visual="Default" />
-    </Grid>
-</Frame>
+    xmlns:magic="clr-namespace:MagicGradients;assembly=MagicGradients">
+    <ContentView.ControlTemplate>
+        <ControlTemplate>
+            <Frame
+                x:Name="TopFrame"
+                Margin="0"
+                Padding="0"
+                HasShadow="False"
+                IsClippedToBounds="True">
+                <Grid>
+                    <magic:GradientView x:Name="GradientView" Margin="-2" />
+                    <Button
+                        x:Name="ActionButton"
+                        BackgroundColor="Transparent"
+                        Visual="Default" />
+                    <ContentPresenter />
+                </Grid>
+            </Frame>
+        </ControlTemplate>
+    </ContentView.ControlTemplate>
+    <!--<Frame
+        x:Name="TopFrame"
+        Margin="0"
+        Padding="0"
+        HasShadow="False"
+        IsClippedToBounds="True">
+        <Grid>
+            <magic:GradientView x:Name="GradientView" Margin="-2" />
+            <Button
+                x:Name="ActionButton"
+                BackgroundColor="Transparent"
+                Visual="Default" />
+        </Grid>
+    </Frame>-->
+</ContentView>

--- a/MagicGradients/Controls/MagicButton.xaml
+++ b/MagicGradients/Controls/MagicButton.xaml
@@ -14,11 +14,11 @@
                 IsClippedToBounds="True">
                 <Grid>
                     <magic:GradientView x:Name="GradientView" Margin="-2" />
+                    <ContentPresenter />
                     <Button
                         x:Name="ActionButton"
                         BackgroundColor="Transparent"
                         Visual="Default" />
-                    <ContentPresenter />
                 </Grid>
             </Frame>
         </ControlTemplate>

--- a/MagicGradients/Controls/MagicButton.xaml
+++ b/MagicGradients/Controls/MagicButton.xaml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ContentView
+    x:Class="MagicGradients.Controls.MagicButton"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:magic="clr-namespace:MagicGradients;assembly=MagicGradients">
+    <ContentView.Content>
+        <Frame
+            x:Name="TopFrame"
+            Margin="0"
+            Padding="0"
+            IsClippedToBounds="True"
+            HasShadow="False">
+            <Grid>
+                <magic:GradientView x:Name="GradientView" Margin="-2" />
+                <Button x:Name="ActionButton" BackgroundColor="Transparent" Visual="Default" />
+            </Grid>
+        </Frame>
+    </ContentView.Content>
+</ContentView>

--- a/MagicGradients/Controls/MagicButton.xaml
+++ b/MagicGradients/Controls/MagicButton.xaml
@@ -9,11 +9,31 @@
             <Frame x:Name="BorderFrame" Margin="0" Padding="0" HasShadow="False" IsClippedToBounds="True">
                 <Grid>
                     <magic:GradientView x:Name="GradientView" />
-                    <ContentPresenter x:Name="ContentPresenter">
-                        <ContentPresenter.GestureRecognizers>
-                            <TapGestureRecognizer x:Name="TapRecognizer" />
-                        </ContentPresenter.GestureRecognizers>
-                    </ContentPresenter>
+                    <ContentPresenter x:Name="ContentPresenter" />
+                    <Button x:Name="CoverButton" HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand" InputTransparent="False">
+                         <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+                                <VisualState x:Name="Normal">
+                                    <VisualState.Setters>
+                                        <Setter Property="Opacity" Value="1" />
+                                        <Setter Property="BackgroundColor" Value="Transparent" />
+                                     </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="Pressed">
+                                    <VisualState.Setters>
+                                        <Setter Property="Opacity" Value="0.7" />
+                                        <Setter Property="BackgroundColor" Value="Black" />
+                                     </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="Disabled">
+                                    <VisualState.Setters>
+                                        <Setter Property="Opacity" Value="0.3" />
+                                        <Setter Property="BackgroundColor" Value="Black" />
+                                     </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                        </Button>
                 </Grid>
             </Frame>
         </ControlTemplate>

--- a/MagicGradients/Controls/MagicButton.xaml.cs
+++ b/MagicGradients/Controls/MagicButton.xaml.cs
@@ -35,6 +35,9 @@ namespace MagicGradients.Controls
         public static readonly BindableProperty HasShadowProperty = BindableProperty.Create(
             nameof(HasShadow), typeof(bool), typeof(MagicButton));
 
+        public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create(
+            nameof(CommandParameter), typeof(object), typeof(MagicButton));
+        
         [TypeConverter(typeof(TextContentTypeConverter))]
         public object Content
         {
@@ -85,6 +88,12 @@ namespace MagicGradients.Controls
             set => SetValue(HasShadowProperty, value);
         }
 
+        public object CommandParameter
+        {
+            get => (object)GetValue(CommandParameterProperty);
+            set => SetValue(CommandParameterProperty, value);
+        }
+        
         public MagicButton()
         {
             InitializeComponent();
@@ -98,7 +107,7 @@ namespace MagicGradients.Controls
 
             var coverButton = (Button)GetTemplateChild("CoverButton");
             coverButton.SetBinding(Button.CommandProperty, new Binding(nameof(Command), source: this));
-            //todo coverButton.SetBinding(Button.CommandParameterProperty);
+            coverButton.SetBinding(Button.CommandParameterProperty, new Binding(nameof(CommandParameter), source: this));
         }
 
         protected override void OnBindingContextChanged()

--- a/MagicGradients/Controls/MagicButton.xaml.cs
+++ b/MagicGradients/Controls/MagicButton.xaml.cs
@@ -3,7 +3,7 @@ using Xamarin.Forms;
 
 namespace MagicGradients.Controls
 {
-     public partial class MagicButton : Frame
+     public partial class MagicButton : ContentView
     {
 
         public static readonly BindableProperty TextProperty = BindableProperty.Create(
@@ -59,15 +59,29 @@ namespace MagicGradients.Controls
         {
             InitializeComponent();
 
-            ActionButton.SetBinding(Button.TextProperty, new Binding(nameof(Text), source: this));
-            ActionButton.SetBinding(Button.FontSizeProperty, new Binding(nameof(FontSize), source: this));
-            ActionButton.SetBinding(Button.TextColorProperty, new Binding(nameof(TextColor), source: this));
-            ActionButton.SetBinding(Button.CommandProperty, new Binding(nameof(Command), source: this));
-            ActionButton.SetBinding(Button.FontFamilyProperty, new Binding(nameof(FontFamily), source: this));
-            
-            GradientView.SetBinding(GradientView.GradientSourceProperty, new Binding(nameof(GradientSource), source: this));
+            //ActionButton.SetBinding(Button.TextProperty, new Binding(nameof(Text), source: this));
+            //ActionButton.SetBinding(Button.FontSizeProperty, new Binding(nameof(FontSize), source: this));
+            //ActionButton.SetBinding(Button.TextColorProperty, new Binding(nameof(TextColor), source: this));
+            //ActionButton.SetBinding(Button.CommandProperty, new Binding(nameof(Command), source: this));
+            //ActionButton.SetBinding(Button.FontFamilyProperty, new Binding(nameof(FontFamily), source: this));
 
-            TopFrame.SetBinding(Frame.CornerRadiusProperty, new Binding(nameof(CornerRadius), source: this));
+            //GradientView.SetBinding(GradientView.GradientSourceProperty, new Binding(nameof(GradientSource), source: this));
+
+            //TopFrame.SetBinding(Frame.CornerRadiusProperty, new Binding(nameof(CornerRadius), source: this));
+
+            var actionButton = (Button)GetTemplateChild("ActionButton");
+            var gradientView = (GradientView)GetTemplateChild("GradientView");
+            var topFrame = (Frame)GetTemplateChild("TopFrame");
+
+            actionButton.SetBinding(Button.TextProperty, new Binding(nameof(Text), source: this));
+            actionButton.SetBinding(Button.FontSizeProperty, new Binding(nameof(FontSize), source: this));
+            actionButton.SetBinding(Button.TextColorProperty, new Binding(nameof(TextColor), source: this));
+            actionButton.SetBinding(Button.CommandProperty, new Binding(nameof(Command), source: this));
+            actionButton.SetBinding(Button.FontFamilyProperty, new Binding(nameof(FontFamily), source: this));
+
+            gradientView.SetBinding(GradientView.GradientSourceProperty, new Binding(nameof(GradientSource), source: this));
+
+            topFrame.SetBinding(Frame.CornerRadiusProperty, new Binding(nameof(CornerRadius), source: this));
         }
         
         public string Text

--- a/MagicGradients/Controls/MagicButton.xaml.cs
+++ b/MagicGradients/Controls/MagicButton.xaml.cs
@@ -20,59 +20,26 @@ namespace MagicGradients.Controls
             TopFrame.SetBinding(Frame.CornerRadiusProperty, new Binding(nameof(CornerRadius), source: this));
         }
 
-        #region Text
-
         public static readonly BindableProperty TextProperty = BindableProperty.Create(
             propertyName: nameof(Text),
             returnType: typeof(string),
             declaringType: typeof(MagicButton),
             defaultValue: default,
             defaultBindingMode: BindingMode.TwoWay);
-
-        public string Text
-        {
-            get => (string)GetValue(TextProperty);
-            set => SetValue(TextProperty, value);
-        }
-
-        #endregion Text
-
-        #region FontSize
-
+        
         public static readonly BindableProperty FontSizeProperty = BindableProperty.Create(
             propertyName: nameof(FontSize),
             returnType: typeof(double),
             declaringType: typeof(MagicButton),
             defaultValue: (double)18,
             defaultBindingMode: BindingMode.TwoWay);
-
-        [TypeConverter(typeof(FontSizeConverter))]
-        public double FontSize
-        {
-            get => (double)GetValue(FontSizeProperty);
-            set => SetValue(FontSizeProperty, value);
-        }
-
-        #endregion FontSize
         
-        #region FontFamily
-
         public static readonly BindableProperty FontFamilyProperty = BindableProperty.Create(
             propertyName: nameof(FontFamily),
             returnType: typeof(string),
             declaringType: typeof(MagicButton),
             defaultValue: default,
             defaultBindingMode: BindingMode.TwoWay);
-
-        public string FontFamily
-        {
-            get => (string)GetValue(FontFamilyProperty);
-            set => SetValue(FontFamilyProperty, value);
-        }
-
-        #endregion FontFamily
-
-        #region TextColor
 
         public static readonly BindableProperty TextColorProperty = BindableProperty.Create(
             propertyName: nameof(TextColor),
@@ -81,32 +48,12 @@ namespace MagicGradients.Controls
             defaultValue: Color.White,
             defaultBindingMode: BindingMode.TwoWay);
 
-        public Color TextColor
-        {
-            get => (Color)GetValue(TextColorProperty);
-            set => SetValue(TextColorProperty, value);
-        }
-
-        #endregion TextColor
-
-        #region GradientSource
-
         public static readonly BindableProperty GradientSourceProperty = BindableProperty.Create(
             propertyName: nameof(GradientSource),
             returnType: typeof(IGradientSource),
             declaringType: typeof(MagicButton),
             defaultValue: null,
             defaultBindingMode: BindingMode.TwoWay);
-
-        public IGradientSource GradientSource
-        {
-            get => (IGradientSource)GetValue(GradientSourceProperty);
-            set => SetValue(GradientSourceProperty, value);
-        }
-
-        #endregion GradientSource
-
-        #region Command
 
         public static readonly BindableProperty CommandProperty = BindableProperty.Create(
             propertyName: nameof(Command),
@@ -115,29 +62,54 @@ namespace MagicGradients.Controls
             defaultValue: null,
             defaultBindingMode: BindingMode.TwoWay);
 
-        public ICommand Command
-        {
-            get => (ICommand)GetValue(CommandProperty);
-            set => SetValue(CommandProperty, value);
-        }
-
-        #endregion Command
-
-        #region CornerRadius
-
         public static readonly BindableProperty CornerRadiusProperty = BindableProperty.Create(
             propertyName: nameof(CornerRadius),
             returnType: typeof(float),
             declaringType: typeof(MagicButton),
             defaultValue: 15f,
             defaultBindingMode: BindingMode.TwoWay);
+        
+        public string Text
+        {
+            get => (string)GetValue(TextProperty);
+            set => SetValue(TextProperty, value);
+        }
+
+        [TypeConverter(typeof(FontSizeConverter))]
+        public double FontSize
+        {
+            get => (double)GetValue(FontSizeProperty);
+            set => SetValue(FontSizeProperty, value);
+        }
+
+        public string FontFamily
+        {
+            get => (string)GetValue(FontFamilyProperty);
+            set => SetValue(FontFamilyProperty, value);
+        }
+
+        public Color TextColor
+        {
+            get => (Color)GetValue(TextColorProperty);
+            set => SetValue(TextColorProperty, value);
+        }
+
+        public IGradientSource GradientSource
+        {
+            get => (IGradientSource)GetValue(GradientSourceProperty);
+            set => SetValue(GradientSourceProperty, value);
+        }
+
+        public ICommand Command
+        {
+            get => (ICommand)GetValue(CommandProperty);
+            set => SetValue(CommandProperty, value);
+        }
 
         public float CornerRadius
         {
             get => (float)GetValue(CornerRadiusProperty);
             set => SetValue(CornerRadiusProperty, value);
         }
-
-        #endregion CornerRadius
     }
 }

--- a/MagicGradients/Controls/MagicButton.xaml.cs
+++ b/MagicGradients/Controls/MagicButton.xaml.cs
@@ -38,6 +38,14 @@ namespace MagicGradients.Controls
         public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create(
             nameof(CommandParameter), typeof(object), typeof(MagicButton));
         
+        public static readonly BindableProperty PressedOpacityProperty = BindableProperty.Create(
+            nameof(PressedOpacity), typeof(double), typeof(MagicButton), 0.7,
+            propertyChanged:  (b, x, y) => ((MagicButton)b).UpdatePressedOpacity());
+        
+        public static readonly BindableProperty DisableOpacityProperty = BindableProperty.Create(
+            nameof(DisableOpacity), typeof(double), typeof(MagicButton), 0.3,
+            propertyChanged:  (b, x, y) => ((MagicButton)b).UpdateDisableOpacity());
+        
         [TypeConverter(typeof(TextContentTypeConverter))]
         public object Content
         {
@@ -92,6 +100,18 @@ namespace MagicGradients.Controls
         {
             get => (object)GetValue(CommandParameterProperty);
             set => SetValue(CommandParameterProperty, value);
+        }
+
+        public double PressedOpacity
+        {
+            get => (double) GetValue(PressedOpacityProperty);
+            set => SetValue(PressedOpacityProperty, value);
+        }
+
+        public double DisableOpacity
+        {
+            get => (double) GetValue(DisableOpacityProperty);
+            set => SetValue(DisableOpacityProperty, value);
         }
         
         public MagicButton()
@@ -181,6 +201,30 @@ namespace MagicGradients.Controls
             {
                 label.TextColor = TextColor;
             }
+        }
+
+        private void UpdateDisableOpacity()
+        {
+            var coverButton = GetTemplateChild("CoverButton") as Button;
+            if (coverButton == null)
+                return;
+            var visualStateGroups = VisualStateManager.GetVisualStateGroups(coverButton);
+            var commonGroup =  visualStateGroups.First();
+            var disabledState = commonGroup.States[2];
+            var opacitySetter = disabledState.Setters[0];
+            opacitySetter.Value = DisableOpacity;
+        }
+
+        private void UpdatePressedOpacity()
+        {
+            var coverButton = GetTemplateChild("CoverButton") as Button;
+            if (coverButton == null)
+                return;
+            var visualStateGroups = VisualStateManager.GetVisualStateGroups(coverButton);
+            var commonGroup =  visualStateGroups.First();
+            var pressedState = commonGroup.States[1];
+            var opacitySetter = pressedState.Setters[0];
+            opacitySetter.Value = PressedOpacity;
         }
     }
 }

--- a/MagicGradients/Controls/MagicButton.xaml.cs
+++ b/MagicGradients/Controls/MagicButton.xaml.cs
@@ -3,22 +3,8 @@ using Xamarin.Forms;
 
 namespace MagicGradients.Controls
 {
-     public partial class MagicButton : ContentView
+     public partial class MagicButton : Frame
     {
-        public MagicButton()
-        {
-            InitializeComponent();
-
-            ActionButton.SetBinding(Button.TextProperty, new Binding(nameof(Text), source: this));
-            ActionButton.SetBinding(Button.FontSizeProperty, new Binding(nameof(FontSize), source: this));
-            ActionButton.SetBinding(Button.TextColorProperty, new Binding(nameof(TextColor), source: this));
-            ActionButton.SetBinding(Button.CommandProperty, new Binding(nameof(Command), source: this));
-            ActionButton.SetBinding(Button.FontFamilyProperty, new Binding(nameof(FontFamily), source: this));
-            
-            GradientView.SetBinding(GradientView.GradientSourceProperty, new Binding(nameof(GradientSource), source: this));
-
-            TopFrame.SetBinding(Frame.CornerRadiusProperty, new Binding(nameof(CornerRadius), source: this));
-        }
 
         public static readonly BindableProperty TextProperty = BindableProperty.Create(
             propertyName: nameof(Text),
@@ -68,6 +54,21 @@ namespace MagicGradients.Controls
             declaringType: typeof(MagicButton),
             defaultValue: 15f,
             defaultBindingMode: BindingMode.TwoWay);
+        
+        public MagicButton()
+        {
+            InitializeComponent();
+
+            ActionButton.SetBinding(Button.TextProperty, new Binding(nameof(Text), source: this));
+            ActionButton.SetBinding(Button.FontSizeProperty, new Binding(nameof(FontSize), source: this));
+            ActionButton.SetBinding(Button.TextColorProperty, new Binding(nameof(TextColor), source: this));
+            ActionButton.SetBinding(Button.CommandProperty, new Binding(nameof(Command), source: this));
+            ActionButton.SetBinding(Button.FontFamilyProperty, new Binding(nameof(FontFamily), source: this));
+            
+            GradientView.SetBinding(GradientView.GradientSourceProperty, new Binding(nameof(GradientSource), source: this));
+
+            TopFrame.SetBinding(Frame.CornerRadiusProperty, new Binding(nameof(CornerRadius), source: this));
+        }
         
         public string Text
         {

--- a/MagicGradients/Controls/MagicButton.xaml.cs
+++ b/MagicGradients/Controls/MagicButton.xaml.cs
@@ -1,130 +1,176 @@
+using System.Linq;
 using System.Windows.Input;
 using Xamarin.Forms;
 
 namespace MagicGradients.Controls
 {
-     public partial class MagicButton : ContentView
+    [ContentProperty("Content")]
+    public partial class MagicButton : TemplatedView
     {
+        public static readonly BindableProperty ContentProperty = BindableProperty.Create(
+            nameof(Content), typeof(object), typeof(MagicButton), null,
+            propertyChanged: OnContentChanged, coerceValue: CoerceContent);
 
-        public static readonly BindableProperty TextProperty = BindableProperty.Create(
-            propertyName: nameof(Text),
-            returnType: typeof(string),
-            declaringType: typeof(MagicButton),
-            defaultValue: default,
-            defaultBindingMode: BindingMode.TwoWay);
-        
         public static readonly BindableProperty FontSizeProperty = BindableProperty.Create(
-            propertyName: nameof(FontSize),
-            returnType: typeof(double),
-            declaringType: typeof(MagicButton),
-            defaultValue: (double)18,
-            defaultBindingMode: BindingMode.TwoWay);
-        
+            nameof(FontSize), typeof(double), typeof(MagicButton), (double)18, 
+            propertyChanged: (b, x, y) => ((MagicButton)b).UpdateFontSize());
+
         public static readonly BindableProperty FontFamilyProperty = BindableProperty.Create(
-            propertyName: nameof(FontFamily),
-            returnType: typeof(string),
-            declaringType: typeof(MagicButton),
-            defaultValue: default,
-            defaultBindingMode: BindingMode.TwoWay);
+            nameof(FontFamily), typeof(string), typeof(MagicButton),
+            propertyChanged: (b, x, y) => ((MagicButton)b).UpdateFontFamily());
 
         public static readonly BindableProperty TextColorProperty = BindableProperty.Create(
-            propertyName: nameof(TextColor),
-            returnType: typeof(Color),
-            declaringType: typeof(MagicButton),
-            defaultValue: Color.White,
-            defaultBindingMode: BindingMode.TwoWay);
+            nameof(TextColor), typeof(Color), typeof(MagicButton), Color.White,
+            propertyChanged: (b, x, y) => ((MagicButton)b).UpdateTextColor());
 
         public static readonly BindableProperty GradientSourceProperty = BindableProperty.Create(
-            propertyName: nameof(GradientSource),
-            returnType: typeof(IGradientSource),
-            declaringType: typeof(MagicButton),
-            defaultValue: null,
-            defaultBindingMode: BindingMode.TwoWay);
+            nameof(GradientSource), typeof(IGradientSource), typeof(MagicButton));
 
         public static readonly BindableProperty CommandProperty = BindableProperty.Create(
-            propertyName: nameof(Command),
-            returnType: typeof(ICommand),
-            declaringType: typeof(MagicButton),
-            defaultValue: null,
-            defaultBindingMode: BindingMode.TwoWay);
+            nameof(Command), typeof(ICommand), typeof(MagicButton));
 
         public static readonly BindableProperty CornerRadiusProperty = BindableProperty.Create(
-            propertyName: nameof(CornerRadius),
-            returnType: typeof(float),
-            declaringType: typeof(MagicButton),
-            defaultValue: 15f,
-            defaultBindingMode: BindingMode.TwoWay);
-        
-        public MagicButton()
+            nameof(CornerRadius), typeof(float), typeof(MagicButton), 15f);
+
+        public static readonly BindableProperty HasShadowProperty = BindableProperty.Create(
+            nameof(HasShadow), typeof(bool), typeof(MagicButton));
+
+        [TypeConverter(typeof(TextContentTypeConverter))]
+        public object Content
         {
-            InitializeComponent();
-
-            //ActionButton.SetBinding(Button.TextProperty, new Binding(nameof(Text), source: this));
-            //ActionButton.SetBinding(Button.FontSizeProperty, new Binding(nameof(FontSize), source: this));
-            //ActionButton.SetBinding(Button.TextColorProperty, new Binding(nameof(TextColor), source: this));
-            //ActionButton.SetBinding(Button.CommandProperty, new Binding(nameof(Command), source: this));
-            //ActionButton.SetBinding(Button.FontFamilyProperty, new Binding(nameof(FontFamily), source: this));
-
-            //GradientView.SetBinding(GradientView.GradientSourceProperty, new Binding(nameof(GradientSource), source: this));
-
-            //TopFrame.SetBinding(Frame.CornerRadiusProperty, new Binding(nameof(CornerRadius), source: this));
-
-            var actionButton = (Button)GetTemplateChild("ActionButton");
-            var gradientView = (GradientView)GetTemplateChild("GradientView");
-            var topFrame = (Frame)GetTemplateChild("TopFrame");
-
-            actionButton.SetBinding(Button.TextProperty, new Binding(nameof(Text), source: this));
-            actionButton.SetBinding(Button.FontSizeProperty, new Binding(nameof(FontSize), source: this));
-            actionButton.SetBinding(Button.TextColorProperty, new Binding(nameof(TextColor), source: this));
-            actionButton.SetBinding(Button.CommandProperty, new Binding(nameof(Command), source: this));
-            actionButton.SetBinding(Button.FontFamilyProperty, new Binding(nameof(FontFamily), source: this));
-
-            gradientView.SetBinding(GradientView.GradientSourceProperty, new Binding(nameof(GradientSource), source: this));
-
-            topFrame.SetBinding(Frame.CornerRadiusProperty, new Binding(nameof(CornerRadius), source: this));
-        }
-        
-        public string Text
-        {
-            get => (string)GetValue(TextProperty);
-            set => SetValue(TextProperty, value);
+            get => GetValue(ContentProperty);
+            set => SetValue(ContentProperty, value);
         }
 
         [TypeConverter(typeof(FontSizeConverter))]
         public double FontSize
         {
-            get => (double)GetValue(FontSizeProperty);
+            get => (double) GetValue(FontSizeProperty);
             set => SetValue(FontSizeProperty, value);
         }
 
         public string FontFamily
         {
-            get => (string)GetValue(FontFamilyProperty);
+            get => (string) GetValue(FontFamilyProperty);
             set => SetValue(FontFamilyProperty, value);
         }
 
         public Color TextColor
         {
-            get => (Color)GetValue(TextColorProperty);
+            get => (Color) GetValue(TextColorProperty);
             set => SetValue(TextColorProperty, value);
         }
 
         public IGradientSource GradientSource
         {
-            get => (IGradientSource)GetValue(GradientSourceProperty);
+            get => (IGradientSource) GetValue(GradientSourceProperty);
             set => SetValue(GradientSourceProperty, value);
         }
 
         public ICommand Command
         {
-            get => (ICommand)GetValue(CommandProperty);
+            get => (ICommand) GetValue(CommandProperty);
             set => SetValue(CommandProperty, value);
         }
 
         public float CornerRadius
         {
-            get => (float)GetValue(CornerRadiusProperty);
+            get => (float) GetValue(CornerRadiusProperty);
             set => SetValue(CornerRadiusProperty, value);
+        }
+
+        public bool HasShadow
+        {
+            get => (bool)GetValue(HasShadowProperty);
+            set => SetValue(HasShadowProperty, value);
+        }
+
+        public MagicButton()
+        {
+            InitializeComponent();
+
+            var actionButton = (ContentPresenter)GetTemplateChild("ContentPresenter");
+            ((TapGestureRecognizer)actionButton.GestureRecognizers.First()).SetBinding(TapGestureRecognizer.CommandProperty, new Binding(nameof(Command), source: this));
+
+            var gradientView = (GradientView)GetTemplateChild("GradientView");
+            gradientView.SetBinding(GradientView.GradientSourceProperty, new Binding(nameof(GradientSource), source: this));
+
+            var border = (Frame)GetTemplateChild("BorderFrame");
+            border.SetBinding(Frame.CornerRadiusProperty, new Binding(nameof(CornerRadius), source: this));
+            border.SetBinding(Frame.HasShadowProperty, new Binding(nameof(HasShadow), source: this));
+        }
+
+        protected override void OnBindingContextChanged()
+        {
+            base.OnBindingContextChanged();
+
+            View content = (View)Content;
+            ControlTemplate controlTemplate = ControlTemplate;
+
+            if (content != null && controlTemplate != null)
+            {
+                SetInheritedBindingContext(content, BindingContext);
+            }
+        }
+
+        protected override void OnApplyTemplate()
+        {
+            View content = (View)Content;
+            ControlTemplate controlTemplate = ControlTemplate;
+
+            if (content != null && controlTemplate != null)
+            {
+                SetInheritedBindingContext(content, BindingContext);
+            }
+        }
+
+        private static void OnContentChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            var newElement = (Element)newValue;
+            if (newElement != null)
+            {
+                SetInheritedBindingContext(newElement, bindable.BindingContext);
+
+                var button = (MagicButton)bindable;
+                button.UpdateFontSize();
+                button.UpdateFontFamily();
+                button.UpdateTextColor();
+            }
+        }
+
+        private static object CoerceContent(BindableObject bindable, object value)
+        {
+            if (value is View view)
+                return view;
+
+            if (value != null)
+                return new TextContent { Text = value.ToString() };
+
+            return null;
+        }
+
+        private void UpdateFontSize()
+        {
+            if (Content is Label label)
+            {
+                label.FontSize = FontSize;
+            }
+        }
+
+        private void UpdateFontFamily()
+        {
+            if (Content is Label label)
+            {
+                label.FontFamily = FontFamily;
+            }
+        }
+
+        private void UpdateTextColor()
+        {
+            if (Content is Label label)
+            {
+                label.TextColor = TextColor;
+            }
         }
     }
 }

--- a/MagicGradients/Controls/MagicButton.xaml.cs
+++ b/MagicGradients/Controls/MagicButton.xaml.cs
@@ -1,0 +1,143 @@
+using System.Windows.Input;
+using Xamarin.Forms;
+
+namespace MagicGradients.Controls
+{
+     public partial class MagicButton : ContentView
+    {
+        public MagicButton()
+        {
+            InitializeComponent();
+
+            ActionButton.SetBinding(Button.TextProperty, new Binding(nameof(Text), source: this));
+            ActionButton.SetBinding(Button.FontSizeProperty, new Binding(nameof(FontSize), source: this));
+            ActionButton.SetBinding(Button.TextColorProperty, new Binding(nameof(TextColor), source: this));
+            ActionButton.SetBinding(Button.CommandProperty, new Binding(nameof(Command), source: this));
+            ActionButton.SetBinding(Button.FontFamilyProperty, new Binding(nameof(FontFamily), source: this));
+            
+            GradientView.SetBinding(GradientView.GradientSourceProperty, new Binding(nameof(GradientSource), source: this));
+
+            TopFrame.SetBinding(Frame.CornerRadiusProperty, new Binding(nameof(CornerRadius), source: this));
+        }
+
+        #region Text
+
+        public static readonly BindableProperty TextProperty = BindableProperty.Create(
+            propertyName: nameof(Text),
+            returnType: typeof(string),
+            declaringType: typeof(MagicButton),
+            defaultValue: default,
+            defaultBindingMode: BindingMode.TwoWay);
+
+        public string Text
+        {
+            get => (string)GetValue(TextProperty);
+            set => SetValue(TextProperty, value);
+        }
+
+        #endregion Text
+
+        #region FontSize
+
+        public static readonly BindableProperty FontSizeProperty = BindableProperty.Create(
+            propertyName: nameof(FontSize),
+            returnType: typeof(double),
+            declaringType: typeof(MagicButton),
+            defaultValue: (double)18,
+            defaultBindingMode: BindingMode.TwoWay);
+
+        [TypeConverter(typeof(FontSizeConverter))]
+        public double FontSize
+        {
+            get => (double)GetValue(FontSizeProperty);
+            set => SetValue(FontSizeProperty, value);
+        }
+
+        #endregion FontSize
+        
+        #region FontFamily
+
+        public static readonly BindableProperty FontFamilyProperty = BindableProperty.Create(
+            propertyName: nameof(FontFamily),
+            returnType: typeof(string),
+            declaringType: typeof(MagicButton),
+            defaultValue: default,
+            defaultBindingMode: BindingMode.TwoWay);
+
+        public string FontFamily
+        {
+            get => (string)GetValue(FontFamilyProperty);
+            set => SetValue(FontFamilyProperty, value);
+        }
+
+        #endregion FontFamily
+
+        #region TextColor
+
+        public static readonly BindableProperty TextColorProperty = BindableProperty.Create(
+            propertyName: nameof(TextColor),
+            returnType: typeof(Color),
+            declaringType: typeof(MagicButton),
+            defaultValue: Color.White,
+            defaultBindingMode: BindingMode.TwoWay);
+
+        public Color TextColor
+        {
+            get => (Color)GetValue(TextColorProperty);
+            set => SetValue(TextColorProperty, value);
+        }
+
+        #endregion TextColor
+
+        #region GradientSource
+
+        public static readonly BindableProperty GradientSourceProperty = BindableProperty.Create(
+            propertyName: nameof(GradientSource),
+            returnType: typeof(IGradientSource),
+            declaringType: typeof(MagicButton),
+            defaultValue: null,
+            defaultBindingMode: BindingMode.TwoWay);
+
+        public IGradientSource GradientSource
+        {
+            get => (IGradientSource)GetValue(GradientSourceProperty);
+            set => SetValue(GradientSourceProperty, value);
+        }
+
+        #endregion GradientSource
+
+        #region Command
+
+        public static readonly BindableProperty CommandProperty = BindableProperty.Create(
+            propertyName: nameof(Command),
+            returnType: typeof(ICommand),
+            declaringType: typeof(MagicButton),
+            defaultValue: null,
+            defaultBindingMode: BindingMode.TwoWay);
+
+        public ICommand Command
+        {
+            get => (ICommand)GetValue(CommandProperty);
+            set => SetValue(CommandProperty, value);
+        }
+
+        #endregion Command
+
+        #region CornerRadius
+
+        public static readonly BindableProperty CornerRadiusProperty = BindableProperty.Create(
+            propertyName: nameof(CornerRadius),
+            returnType: typeof(float),
+            declaringType: typeof(MagicButton),
+            defaultValue: 15f,
+            defaultBindingMode: BindingMode.TwoWay);
+
+        public float CornerRadius
+        {
+            get => (float)GetValue(CornerRadiusProperty);
+            set => SetValue(CornerRadiusProperty, value);
+        }
+
+        #endregion CornerRadius
+    }
+}

--- a/MagicGradients/Controls/MagicButton.xaml.cs
+++ b/MagicGradients/Controls/MagicButton.xaml.cs
@@ -89,15 +89,16 @@ namespace MagicGradients.Controls
         {
             InitializeComponent();
 
-            var actionButton = (ContentPresenter)GetTemplateChild("ContentPresenter");
-            ((TapGestureRecognizer)actionButton.GestureRecognizers.First()).SetBinding(TapGestureRecognizer.CommandProperty, new Binding(nameof(Command), source: this));
-
             var gradientView = (GradientView)GetTemplateChild("GradientView");
             gradientView.SetBinding(GradientView.GradientSourceProperty, new Binding(nameof(GradientSource), source: this));
 
             var border = (Frame)GetTemplateChild("BorderFrame");
             border.SetBinding(Frame.CornerRadiusProperty, new Binding(nameof(CornerRadius), source: this));
             border.SetBinding(Frame.HasShadowProperty, new Binding(nameof(HasShadow), source: this));
+
+            var coverButton = (Button)GetTemplateChild("CoverButton");
+            coverButton.SetBinding(Button.CommandProperty, new Binding(nameof(Command), source: this));
+            //todo coverButton.SetBinding(Button.CommandParameterProperty);
         }
 
         protected override void OnBindingContextChanged()

--- a/MagicGradients/Controls/MagicButton.xaml.cs
+++ b/MagicGradients/Controls/MagicButton.xaml.cs
@@ -46,6 +46,12 @@ namespace MagicGradients.Controls
             nameof(DisableOpacity), typeof(double), typeof(MagicButton), 0.3,
             propertyChanged:  (b, x, y) => ((MagicButton)b).UpdateDisableOpacity());
         
+        public static readonly BindableProperty GradientSizeProperty = BindableProperty.Create(nameof(GradientSize),
+            typeof(Dimensions), typeof(GradientView));
+
+        public static readonly BindableProperty GradientRepeatProperty = BindableProperty.Create(nameof(GradientRepeat),
+            typeof(BackgroundRepeat), typeof(GradientView));
+        
         [TypeConverter(typeof(TextContentTypeConverter))]
         public object Content
         {
@@ -76,6 +82,18 @@ namespace MagicGradients.Controls
         {
             get => (IGradientSource) GetValue(GradientSourceProperty);
             set => SetValue(GradientSourceProperty, value);
+        }
+        
+        public Dimensions GradientSize
+        {
+            get => (Dimensions)GetValue(GradientSizeProperty);
+            set => SetValue(GradientSizeProperty, value);
+        }
+
+        public BackgroundRepeat GradientRepeat
+        {
+            get => (BackgroundRepeat)GetValue(GradientRepeatProperty);
+            set => SetValue(GradientRepeatProperty, value);
         }
 
         public ICommand Command

--- a/MagicGradients/Controls/TextContent.cs
+++ b/MagicGradients/Controls/TextContent.cs
@@ -1,0 +1,15 @@
+﻿using Xamarin.Forms;
+
+namespace MagicGradients.Controls
+{
+    public class TextContent : Label
+    {
+        public TextContent()
+        {
+            HorizontalOptions = LayoutOptions.Fill;
+            VerticalOptions = LayoutOptions.Fill;
+            HorizontalTextAlignment = TextAlignment.Center;
+            VerticalTextAlignment = TextAlignment.Center;
+        }
+    }
+}

--- a/MagicGradients/Controls/TextContentTypeConverter.cs
+++ b/MagicGradients/Controls/TextContentTypeConverter.cs
@@ -1,0 +1,17 @@
+﻿using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace MagicGradients.Controls
+{
+    [TypeConversion(typeof(TextContent))]
+    public class TextContentTypeConverter : TypeConverter
+    {
+        public override object ConvertFromInvariantString(string value)
+        {
+            return new TextContent
+            {
+                Text = value
+            };
+        }
+    }
+}

--- a/MagicGradients/GradientStop.cs
+++ b/MagicGradients/GradientStop.cs
@@ -26,7 +26,7 @@ namespace MagicGradients
 
         public override string ToString()
         {
-            return $"Offset={Offset}, Color=[{Color.ToString()}]";
+            return $"Offset={Offset}, Color=[{Color}]";
         }
     }
 }

--- a/Playground/Playground/App.xaml
+++ b/Playground/Playground/App.xaml
@@ -4,6 +4,7 @@
              xmlns:d="http://xamarin.com/schemas/2014/forms/design"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:viewModels="clr-namespace:Playground.ViewModels;assembly=Playground"
+             xmlns:controls="clr-namespace:MagicGradients.Controls;assembly=MagicGradients"
              mc:Ignorable="d"
              x:Class="Playground.App">
     <Application.Resources>

--- a/Playground/Playground/ViewModels/BattleTestViewModel.cs
+++ b/Playground/Playground/ViewModels/BattleTestViewModel.cs
@@ -80,6 +80,7 @@ namespace Playground.ViewModels
 
         public List<string> ColorNames { get; }
         public ICommand ClickCommand { get; }
+        public ICommand DisabledCommand { get; }
         public string MagicButtonText { get; } = "My Content is bindable";
 
         public BattleTestViewModel(
@@ -97,6 +98,7 @@ namespace Playground.ViewModels
             {
                 Application.Current.MainPage.DisplayAlert("","Button Clicked", "OK");
             });
+            DisabledCommand = new Command(() => { }, () => false);
         }
 
         private void LoadCssCodeById()

--- a/Playground/Playground/ViewModels/BattleTestViewModel.cs
+++ b/Playground/Playground/ViewModels/BattleTestViewModel.cs
@@ -5,6 +5,7 @@ using Playground.Data.Repositories;
 using Playground.Models;
 using Playground.Services;
 using System.Collections.Generic;
+using System.Windows.Input;
 using Xamarin.Forms;
 using static Playground.Constants.IconCodes;
 using Color = System.Drawing.Color;
@@ -78,6 +79,8 @@ namespace Playground.ViewModels
 
         public List<string> ColorNames { get; }
 
+        public ICommand ClickCommand { get; }
+
         public BattleTestViewModel(
             IGradientRepository gradientRepository, 
             IPickerColorsDataProvider pickerColorsDataProvider,
@@ -89,6 +92,10 @@ namespace Playground.ViewModels
 
             ColorNames = _pickerColorsDataProvider.GetColorNames();
             TextColor = Color.White;
+            ClickCommand = new Command(() =>
+            {
+                Application.Current.MainPage.DisplayAlert("","Button Clicked", "OK");
+            });
         }
 
         private void LoadCssCodeById()

--- a/Playground/Playground/ViewModels/BattleTestViewModel.cs
+++ b/Playground/Playground/ViewModels/BattleTestViewModel.cs
@@ -18,6 +18,7 @@ namespace Playground.ViewModels
         private readonly IGradientRepository _gradientRepository;
         private readonly IPickerColorsDataProvider _pickerColorsDataProvider;
         private readonly IBattleItemService _battleItemService;
+
         private List<BattleItem> _iconsCollection;
         public List<BattleItem> IconsCollection
         {
@@ -78,8 +79,8 @@ namespace Playground.ViewModels
         }
 
         public List<string> ColorNames { get; }
-
         public ICommand ClickCommand { get; }
+        public string MagicButtonText { get; } = "My Content is bindable";
 
         public BattleTestViewModel(
             IGradientRepository gradientRepository, 

--- a/Playground/Playground/ViewModels/BattleTestViewModel.cs
+++ b/Playground/Playground/ViewModels/BattleTestViewModel.cs
@@ -80,6 +80,7 @@ namespace Playground.ViewModels
 
         public List<string> ColorNames { get; }
         public ICommand ClickCommand { get; }
+        public ICommand WithParameterCommand { get; }
         public ICommand DisabledCommand { get; }
         public string MagicButtonText { get; } = "My Content is bindable";
 
@@ -97,6 +98,10 @@ namespace Playground.ViewModels
             ClickCommand = new Command(() =>
             {
                 Application.Current.MainPage.DisplayAlert("","Button Clicked", "OK");
+            });
+            WithParameterCommand = new Command<Color>((color) =>
+            {
+                Application.Current.MainPage.DisplayAlert("", $"Text Color -> {color}", "OK");
             });
             DisabledCommand = new Command(() => { }, () => false);
         }

--- a/Playground/Playground/Views/BattleTestPage.xaml
+++ b/Playground/Playground/Views/BattleTestPage.xaml
@@ -49,13 +49,14 @@
                 </Grid>
             </controls:MagicButton>
             <!--  Circle With Icon And With Gradient Background  -->
-            <CollectionView HeightRequest="50" ItemsSource="{Binding IconsCollection}">
+            <CollectionView HeightRequest="60" ItemsSource="{Binding IconsCollection}">
                 <CollectionView.ItemsLayout>
                     <GridItemsLayout HorizontalItemSpacing="5" Orientation="Horizontal" />
                 </CollectionView.ItemsLayout>
                 <CollectionView.ItemTemplate>
                     <DataTemplate>
                         <controls:MagicButton
+                            Padding="0,5"
                             CornerRadius="25"
                             FontFamily="IconFont"
                             FontSize="16"

--- a/Playground/Playground/Views/BattleTestPage.xaml
+++ b/Playground/Playground/Views/BattleTestPage.xaml
@@ -21,6 +21,8 @@
                 Command="{Binding ClickCommand}"
                 CornerRadius="10"
                 FontSize="16"
+                PressedOpacity="0.3"
+                DisableOpacity="0.7"
                 GradientSource="{Binding GradientSource}"
                 HeightRequest="50"
                 Content="MagicGradients Large Button"

--- a/Playground/Playground/Views/BattleTestPage.xaml
+++ b/Playground/Playground/Views/BattleTestPage.xaml
@@ -4,6 +4,7 @@
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:magic="clr-namespace:MagicGradients;assembly=MagicGradients"
+    xmlns:controls="clr-namespace:MagicGradients.Controls;assembly=MagicGradients"
     x:Name="battlePage"
     Title="Gradient Battle Test"
     BindingContext="{Binding BattleTestViewModel, Source={StaticResource ViewModelLocator}, Mode=OneTime}">
@@ -16,36 +17,22 @@
                 ItemsSource="{Binding ColorNames}"
                 SelectedIndex="{Binding SelectedColorIndex}" />
             <!--  Buttons With Gradient Background  -->
-            <Frame
-                Padding="0"
+            <controls:MagicButton
                 CornerRadius="10"
-                HasShadow="False">
-                <Grid>
-                    <magic:GradientView GradientSource="{Binding GradientSource}" />
-                    <Button
-                        BackgroundColor="Transparent"
-                        FontSize="16"
-                        HeightRequest="100"
-                        Text="MagicGradients Large Button"
-                        TextColor="{Binding TextColor}" />
-                </Grid>
-            </Frame>
-            <Frame
-                Padding="0"
+                GradientSource="{Binding GradientSource}"
+                FontSize="16"
+                HeightRequest="100"
+                Text="MagicGradients Large Button"
+                TextColor="{Binding TextColor}"/>
+            <controls:MagicButton
                 CornerRadius="10"
-                HasShadow="False"
+                GradientSource="{Binding GradientSource}"
+                FontSize="16"
+                WidthRequest="150"
+                HeightRequest="50"
                 HorizontalOptions="Center"
-                WidthRequest="150">
-                <Grid>
-                    <magic:GradientView GradientSource="{Binding GradientSource}" />
-                    <Button
-                        BackgroundColor="Transparent"
-                        FontSize="16"
-                        HeightRequest="50"
-                        Text="Small Button"
-                        TextColor="{Binding TextColor}" />
-                </Grid>
-            </Frame>
+                Text="Small Button"
+                TextColor="{Binding TextColor}"/>
             <!--  Circle With Icon And With Gradient Background  -->
             <CollectionView HeightRequest="50" ItemsSource="{Binding IconsCollection}">
                 <CollectionView.ItemsLayout>
@@ -53,21 +40,16 @@
                 </CollectionView.ItemsLayout>
                 <CollectionView.ItemTemplate>
                     <DataTemplate>
-                        <Frame
-                            Padding="0"
+                        <controls:MagicButton
                             CornerRadius="25"
-                            HasShadow="False"
-                            WidthRequest="50">
-                            <Grid>
-                                <magic:GradientView GradientSource="{Binding GradientSource}" />
-                                <Button
-                                    BackgroundColor="Transparent"
-                                    FontFamily="IconFont"
-                                    FontSize="16"
-                                    Text="{Binding Text}"
-                                    TextColor="{Binding TextColor}" />
-                            </Grid>
-                        </Frame>
+                            GradientSource="{Binding GradientSource}"
+                            FontSize="16"
+                            WidthRequest="50"
+                            HeightRequest="50"
+                            HorizontalOptions="Center"
+                            Text="{Binding Text}"
+                            FontFamily="IconFont"
+                            TextColor="{Binding TextColor}"/>
                     </DataTemplate>
                 </CollectionView.ItemTemplate>
             </CollectionView>

--- a/Playground/Playground/Views/BattleTestPage.xaml
+++ b/Playground/Playground/Views/BattleTestPage.xaml
@@ -35,7 +35,7 @@
                 TextColor="{Binding TextColor}"
                 HasShadow="True" />
             <controls:MagicButton
-                Command="{Binding ClickCommand}"
+                Command="{Binding DisabledCommand}"
                 CornerRadius="10"
                 FontSize="16"
                 GradientSource="{Binding GradientSource}"

--- a/Playground/Playground/Views/BattleTestPage.xaml
+++ b/Playground/Playground/Views/BattleTestPage.xaml
@@ -26,7 +26,8 @@
                 Content="MagicGradients Large Button"
                 TextColor="{Binding TextColor}" />
             <controls:MagicButton
-                Command="{Binding ClickCommand}"
+                Command="{Binding WithParameterCommand}"
+                CommandParameter="{Binding TextColor}"
                 CornerRadius="10"
                 FontSize="16"
                 GradientSource="{Binding GradientSource}"

--- a/Playground/Playground/Views/BattleTestPage.xaml
+++ b/Playground/Playground/Views/BattleTestPage.xaml
@@ -18,31 +18,34 @@
                 SelectedIndex="{Binding SelectedColorIndex}" />
             <!--  Buttons With Gradient Background  -->
             <controls:MagicButton
+                Command="{Binding ClickCommand}"
                 CornerRadius="10"
                 FontSize="16"
                 GradientSource="{Binding GradientSource}"
                 HeightRequest="100"
-                Command="{Binding ClickCommand}"
                 Text="MagicGradients Large Button"
                 TextColor="{Binding TextColor}" />
             <controls:MagicButton
+                Command="{Binding ClickCommand}"
                 CornerRadius="10"
                 FontSize="16"
                 GradientSource="{Binding GradientSource}"
                 HeightRequest="50"
-                Command="{Binding ClickCommand}"
                 HorizontalOptions="Center"
                 WidthRequest="150">
                 <Grid>
                     <Label
+                        Margin="10"
                         HorizontalTextAlignment="Start"
                         Text="Small"
                         TextColor="{Binding TextColor}"
-                        VerticalOptions="Center" />
+                        VerticalOptions="End" />
                     <Label
+                        Margin="10"
                         HorizontalTextAlignment="End"
                         Text="Button"
-                        TextColor="{Binding TextColor}" />
+                        TextColor="{Binding TextColor}"
+                        VerticalOptions="Start" />
                 </Grid>
             </controls:MagicButton>
             <!--  Circle With Icon And With Gradient Background  -->

--- a/Playground/Playground/Views/BattleTestPage.xaml
+++ b/Playground/Playground/Views/BattleTestPage.xaml
@@ -5,7 +5,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:controls="clr-namespace:MagicGradients.Controls;assembly=MagicGradients"
     xmlns:magic="clr-namespace:MagicGradients;assembly=MagicGradients"
-    x:Name="battlePage"
+    xmlns:ic="clr-namespace:Playground.Constants;assembly=Playground"
     Title="Gradient Battle Test"
     BindingContext="{Binding BattleTestViewModel, Source={StaticResource ViewModelLocator}, Mode=OneTime}">
     <ScrollView>
@@ -22,8 +22,8 @@
                 CornerRadius="10"
                 FontSize="16"
                 GradientSource="{Binding GradientSource}"
-                HeightRequest="100"
-                Text="MagicGradients Large Button"
+                HeightRequest="50"
+                Content="MagicGradients Large Button"
                 TextColor="{Binding TextColor}" />
             <controls:MagicButton
                 Command="{Binding ClickCommand}"
@@ -31,22 +31,26 @@
                 FontSize="16"
                 GradientSource="{Binding GradientSource}"
                 HeightRequest="50"
+                Content="{Binding MagicButtonText}"
+                TextColor="{Binding TextColor}"
+                HasShadow="True" />
+            <controls:MagicButton
+                Command="{Binding ClickCommand}"
+                CornerRadius="10"
+                FontSize="16"
+                GradientSource="{Binding GradientSource}"
                 HorizontalOptions="Center"
-                WidthRequest="150">
-                <Grid>
-                    <Label
-                        Margin="10"
-                        HorizontalTextAlignment="Start"
-                        Text="Small"
-                        TextColor="{Binding TextColor}"
-                        VerticalOptions="End" />
-                    <Label
-                        Margin="10"
-                        HorizontalTextAlignment="End"
-                        Text="Button"
-                        TextColor="{Binding TextColor}"
-                        VerticalOptions="Start" />
-                </Grid>
+                HasShadow="True"
+                WidthRequest="200">
+                <StackLayout Orientation="Horizontal" Padding="10">
+                    <Label FontFamily="IconFont" FontSize="20" 
+                           Text="{x:Static ic:IconCodes.Bolt}" 
+                           TextColor="{Binding TextColor}" 
+                           VerticalOptions="Center" Margin="5,0" />
+                    <Label FontSize="16" Text="Magic Button" 
+                           TextColor="{Binding TextColor}" 
+                           VerticalOptions="Center"/>
+                </StackLayout>
             </controls:MagicButton>
             <!--  Circle With Icon And With Gradient Background  -->
             <CollectionView HeightRequest="60" ItemsSource="{Binding IconsCollection}">
@@ -63,7 +67,7 @@
                             GradientSource="{Binding GradientSource}"
                             HeightRequest="50"
                             HorizontalOptions="Center"
-                            Text="{Binding Text}"
+                            Content="{Binding Text}"
                             TextColor="{Binding TextColor}"
                             WidthRequest="50" />
                     </DataTemplate>

--- a/Playground/Playground/Views/BattleTestPage.xaml
+++ b/Playground/Playground/Views/BattleTestPage.xaml
@@ -3,8 +3,8 @@
     x:Class="Playground.Views.BattleTestPage"
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:magic="clr-namespace:MagicGradients;assembly=MagicGradients"
     xmlns:controls="clr-namespace:MagicGradients.Controls;assembly=MagicGradients"
+    xmlns:magic="clr-namespace:MagicGradients;assembly=MagicGradients"
     x:Name="battlePage"
     Title="Gradient Battle Test"
     BindingContext="{Binding BattleTestViewModel, Source={StaticResource ViewModelLocator}, Mode=OneTime}">
@@ -19,20 +19,32 @@
             <!--  Buttons With Gradient Background  -->
             <controls:MagicButton
                 CornerRadius="10"
-                GradientSource="{Binding GradientSource}"
                 FontSize="16"
+                GradientSource="{Binding GradientSource}"
                 HeightRequest="100"
+                Command="{Binding ClickCommand}"
                 Text="MagicGradients Large Button"
-                TextColor="{Binding TextColor}"/>
+                TextColor="{Binding TextColor}" />
             <controls:MagicButton
                 CornerRadius="10"
-                GradientSource="{Binding GradientSource}"
                 FontSize="16"
-                WidthRequest="150"
+                GradientSource="{Binding GradientSource}"
                 HeightRequest="50"
+                Command="{Binding ClickCommand}"
                 HorizontalOptions="Center"
-                Text="Small Button"
-                TextColor="{Binding TextColor}"/>
+                WidthRequest="150">
+                <Grid>
+                    <Label
+                        HorizontalTextAlignment="Start"
+                        Text="Small"
+                        TextColor="{Binding TextColor}"
+                        VerticalOptions="Center" />
+                    <Label
+                        HorizontalTextAlignment="End"
+                        Text="Button"
+                        TextColor="{Binding TextColor}" />
+                </Grid>
+            </controls:MagicButton>
             <!--  Circle With Icon And With Gradient Background  -->
             <CollectionView HeightRequest="50" ItemsSource="{Binding IconsCollection}">
                 <CollectionView.ItemsLayout>
@@ -42,14 +54,14 @@
                     <DataTemplate>
                         <controls:MagicButton
                             CornerRadius="25"
-                            GradientSource="{Binding GradientSource}"
+                            FontFamily="IconFont"
                             FontSize="16"
-                            WidthRequest="50"
+                            GradientSource="{Binding GradientSource}"
                             HeightRequest="50"
                             HorizontalOptions="Center"
                             Text="{Binding Text}"
-                            FontFamily="IconFont"
-                            TextColor="{Binding TextColor}"/>
+                            TextColor="{Binding TextColor}"
+                            WidthRequest="50" />
                     </DataTemplate>
                 </CollectionView.ItemTemplate>
             </CollectionView>


### PR DESCRIPTION
# Magic Button Control
Resolves #118 

## API Changes

**N/A**

## New Built-in Control in NuGet



`MagicButton` control in `MagicGradients.Controls` namespace with next bindable properties:



| Property | Type | Converter |
|---|---|---|
| Text | string | 
| FontSize | double | Xamarin.Forms.FontSizeConverter | 
| FontFamily | string | 
| TextColor | Xamarin.Forms.Color | 
| GradientSource | MagicGradients.IGradientSource | 
| Command | System.Windows.Input.ICommand | 
| CornerRadius | float | 