### PR TITLE
GPU accelerated rendering

### DIFF
--- a/MagicGradients/Gradient.cs
+++ b/MagicGradients/Gradient.cs
@@ -44,7 +44,7 @@ namespace MagicGradients
             Stops.SetInheritedBindingContext(BindingContext);
         }
 
-        public virtual void PrepareShader(GradientView view)
+        public virtual void PrepareShader(BindableObject view)
         {
 
         }

--- a/MagicGradients/GradientControl.cs
+++ b/MagicGradients/GradientControl.cs
@@ -1,0 +1,51 @@
+﻿using MagicGradients.Masks;
+using Xamarin.Forms;
+
+namespace MagicGradients
+{
+    static class GradientControl
+    {
+        public static readonly BindableProperty GradientSourceProperty = BindableProperty.Create(
+            nameof(IGradientControl.GradientSource), 
+            typeof(IGradientSource),
+            typeof(IGradientControl), 
+            propertyChanged: OnGradientElementChanged);
+
+        public static readonly BindableProperty GradientSizeProperty = BindableProperty.Create(
+            nameof(IGradientControl.GradientSize), 
+            typeof(Dimensions), 
+            typeof(IGradientControl), 
+            propertyChanged: UpdateCanvas);
+
+        public static readonly BindableProperty GradientRepeatProperty = BindableProperty.Create(
+            nameof(IGradientControl.GradientRepeat), 
+            typeof(BackgroundRepeat), 
+            typeof(IGradientControl), 
+            propertyChanged: UpdateCanvas);
+
+        public static readonly BindableProperty MaskProperty = BindableProperty.Create(
+            nameof(IGradientControl.Mask),
+            typeof(GradientMask), 
+            typeof(IGradientControl), 
+            propertyChanged: OnGradientElementChanged);
+
+        private static void OnGradientElementChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            var visualElement = (IGradientVisualElement)bindable;
+
+            if (oldValue != null && oldValue is GradientElement oldElem)
+                oldElem.Parent = null;
+
+            if (newValue != null && newValue is GradientElement newElem)
+                newElem.Parent = visualElement;
+
+            visualElement.InvalidateCanvas();
+        }
+
+        static void UpdateCanvas(BindableObject bindable, object oldValue, object newValue)
+        {
+            var visualElement = (IGradientVisualElement)bindable;
+            visualElement.InvalidateCanvas();
+        }
+    }
+}

--- a/MagicGradients/GradientGLView.cs
+++ b/MagicGradients/GradientGLView.cs
@@ -6,15 +6,8 @@ using Xamarin.Forms;
 namespace MagicGradients
 {
     [ContentProperty(nameof(GradientSource))]
-    public class GradientView : SKCanvasView, IGradientControl, IGradientVisualElement
+    public class GradientGLView : SKGLView, IGradientControl, IGradientVisualElement
     {
-        static GradientView()
-        {
-            StyleSheets.RegisterStyle("background", typeof(GradientView), nameof(GradientSourceProperty));
-            StyleSheets.RegisterStyle("background-size", typeof(GradientView), nameof(GradientSizeProperty));
-            StyleSheets.RegisterStyle("background-repeat", typeof(GradientView), nameof(GradientRepeatProperty));
-        }
-
         public GradientRenderer Renderer { get; protected set; }
 
         public static readonly BindableProperty GradientSourceProperty = GradientControl.GradientSourceProperty;
@@ -46,7 +39,7 @@ namespace MagicGradients
             set => SetValue(MaskProperty, value);
         }
 
-        public GradientView()
+        public GradientGLView()
         {
             Renderer = new GradientRenderer(this);
         }
@@ -66,7 +59,7 @@ namespace MagicGradients
             }
         }
 
-        protected override void OnPaintSurface(SKPaintSurfaceEventArgs e)
+        protected override void OnPaintSurface(SKPaintGLSurfaceEventArgs e)
         {
             base.OnPaintSurface(e);
 

--- a/MagicGradients/GradientView.cs
+++ b/MagicGradients/GradientView.cs
@@ -2,6 +2,8 @@ using MagicGradients.Masks;
 using MagicGradients.Renderers;
 using SkiaSharp.Views.Forms;
 using Xamarin.Forms;
+using SKCanvasView = SkiaSharp.Views.Forms.SKCanvasView;
+//using SKCanvasView = SkiaSharp.Views.Forms.SKGLView;
 
 namespace MagicGradients
 {
@@ -102,21 +104,23 @@ namespace MagicGradients
             if (GradientSource == null)
                 return;
 
-            //Renderer ??= new GradientRenderer(this);
-
             var context = Renderer.CreateContext(e);
-            using (context.Paint)
-            {
-                foreach (var gradient in GradientSource.GetGradients())
-                {
-                    if (gradient.Shader == null)
-                        gradient.PrepareShader(this);
-
-                    gradient.Measure(context.RenderRect.Width, context.RenderRect.Height);
-                    Renderer.Render(context, gradient.Shader);
-                }
-            }
+            Renderer.RenderGradients(context);
         }
+
+        //protected override void OnPaintSurface(SKPaintGLSurfaceEventArgs e)
+        //{
+        //    base.OnPaintSurface(e);
+
+        //    var canvas = e.Surface.Canvas;
+        //    canvas.Clear();
+
+        //    if (GradientSource == null)
+        //        return;
+
+        //    var context = Renderer.CreateContext(e);
+        //    Renderer.RenderGradients(context);
+        //}
 
         public void InvalidateCanvas()
         {

--- a/MagicGradients/IGradientControl.cs
+++ b/MagicGradients/IGradientControl.cs
@@ -1,0 +1,12 @@
+﻿using MagicGradients.Masks;
+
+namespace MagicGradients
+{
+    public interface IGradientControl
+    {
+        IGradientSource GradientSource { get; set; }
+        Dimensions GradientSize { get; set; }
+        BackgroundRepeat GradientRepeat { get; set; }
+        GradientMask Mask { get; set; }
+    }
+}

--- a/MagicGradients/LinearGradient.cs
+++ b/MagicGradients/LinearGradient.cs
@@ -22,7 +22,7 @@ namespace MagicGradients
         public static bool GetUseLegacyShader(BindableObject view) => (bool)view.GetValue(UseLegacyShaderProperty);
         public static void SetUseLegacyShader(BindableObject view, bool value) => view.SetValue(UseLegacyShaderProperty, value);
 
-        public override void PrepareShader(GradientView view)
+        public override void PrepareShader(BindableObject view)
         {
             if (GetUseLegacyShader(view))
                 Shader = new LinearGradientShaderLegacy(this);
@@ -32,16 +32,16 @@ namespace MagicGradients
 
         private static void OnUseLegacyShaderChanged(BindableObject bindable, object oldValue, object newValue)
         {
-            var view = (GradientView)bindable;
+            var view = (IGradientControl)bindable;
 
             if (view.GradientSource != null)
             {
                 foreach (var gradient in view.GradientSource.GetGradients().Where(x => x is LinearGradient))
                 {
-                    gradient.PrepareShader(view);
+                    gradient.PrepareShader(bindable);
                 }
 
-                view.InvalidateCanvas();
+                ((IGradientVisualElement)view).InvalidateCanvas();
             }
         }
     }

--- a/MagicGradients/RadialGradient.cs
+++ b/MagicGradients/RadialGradient.cs
@@ -59,7 +59,7 @@ namespace MagicGradients
             set => SetValue(SizeProperty, value);
         }
 
-        public override void PrepareShader(GradientView view)
+        public override void PrepareShader(BindableObject view)
         {
             Shader = new RadialGradientShader(this);
         }

--- a/MagicGradients/Renderers/GradientRenderer.cs
+++ b/MagicGradients/Renderers/GradientRenderer.cs
@@ -1,15 +1,16 @@
 ﻿using SkiaSharp;
 using SkiaSharp.Views.Forms;
 using System;
+using Xamarin.Forms;
 using static MagicGradients.BackgroundRepeat;
 
 namespace MagicGradients.Renderers
 {
     public class GradientRenderer
     {
-        private readonly GradientView _control;
+        private readonly IGradientControl _control;
 
-        public GradientRenderer(GradientView control)
+        public GradientRenderer(IGradientControl control)
         {
             _control = control;
         }
@@ -23,7 +24,7 @@ namespace MagicGradients.Renderers
                 CanvasRect = e.Info.Rect
             };
 
-            PrepareContext(context);
+            CalculateRenderSize(context);
             return context;
         }
 
@@ -36,11 +37,11 @@ namespace MagicGradients.Renderers
                 CanvasRect = e.BackendRenderTarget.Rect
             };
 
-            PrepareContext(context);
+            CalculateRenderSize(context);
             return context;
         }
 
-        private void PrepareContext(RenderContext context)
+        private void CalculateRenderSize(RenderContext context)
         {
             var size = _control.GradientSize;
 
@@ -62,14 +63,14 @@ namespace MagicGradients.Renderers
             }
         }
 
-        public void RenderGradients(RenderContext context)
+        public void PaintSurface(RenderContext context)
         {
             using (context.Paint)
             {
                 foreach (var gradient in _control.GradientSource.GetGradients())
                 {
                     if (gradient.Shader == null)
-                        gradient.PrepareShader(_control);
+                        gradient.PrepareShader((BindableObject)_control);
 
                     gradient.Measure(context.RenderRect.Width, context.RenderRect.Height);
                     Render(context, gradient.Shader);

--- a/Playground/Playground/Features/Animation/AnimationsPage.xaml
+++ b/Playground/Playground/Features/Animation/AnimationsPage.xaml
@@ -190,10 +190,9 @@
             </controls:AnimationClip>
             <controls:AnimationClip BindingContext="{Binding IndicatorAnimation}">
                 <magic:GradientView HorizontalOptions="Center"
-                                    HeightRequest="150" WidthRequest="450"
-                                    GradientSize="150,150"
-                                    GradientRepeat="RepeatX"
-                                    IgnorePixelScaling="True">
+                                    WidthRequest="300" HeightRequest="150" 
+                                    GradientSize="50%,100%"
+                                    GradientRepeat="RepeatX">
                     <magic:GradientView.Mask>
                         <masks:MaskCollection>
                             <masks:EllipseMask ClipMode="Include" Size="90%,90%" />

--- a/Playground/Playground/Features/Editor/GradientEditorPage.xaml
+++ b/Playground/Playground/Features/Editor/GradientEditorPage.xaml
@@ -51,16 +51,16 @@
         </VisualStateGroup>
     </VisualStateManager.VisualStateGroups>
 
-    <Grid RowSpacing="0" ColumnDefinitions="*,Auto" RowDefinitions="*,Auto">
+    <Grid x:Name="RootLayout" ColumnDefinitions="*,Auto" RowDefinitions="*,Auto" ColumnSpacing="0" RowSpacing="0" >
         <controls:CheckeredView />
-        <magic:GradientView GradientSource="{Binding GradientSource}" 
+        <!--<magic:GradientView GradientSource="{Binding GradientSource}" 
                             GradientSize="{Binding GradientSize}"
                             GradientRepeat="{Binding GradientRepeat}"
                             Mask="{Binding Mask.Collection}"
                             EnableTouchEvents="{Binding IsDragEnabled}" 
                             Touch="SKCanvasView_OnTouch" 
                             magic:LinearGradient.UseLegacyShader="{Binding Linear.UseLegacyShader}"
-                            PaintSurface="SKCanvasView_OnPaintSurface"/>
+                            PaintSurface="SKCanvasView_OnPaintSurface"/>-->
         
         <Grid VerticalOptions="Start" HorizontalOptions="End" IsVisible="{Binding IsDragEnabled}">
             <BoxView Style="{StaticResource SemiTransparent}" HeightRequest="20" />
@@ -106,7 +106,14 @@
             <tabs:ViewSwitcher x:Name="Switcher" Grid.Row="1" Grid.Column="1"
                                SelectedIndex="{Binding SelectedTabIndex, Mode=TwoWay}">
                 <ScrollView>
-                    <editor:PropertiesTab Margin="10" />
+                    <StackLayout>
+                        <editor:PropertiesTab Margin="10" />
+                        <Label Text="Rendering" Margin="10,10,10,0" />
+                        <Grid ColumnDefinitions="*,*" Margin="10,0">
+                            <Button x:Name="SoftButton" Text="Software" Clicked="SoftButton_OnClicked" />
+                            <Button x:Name="GpuButton" Text="Accelerated" Clicked="GpuButton_OnClicked" Grid.Column="1" />
+                        </Grid>
+                    </StackLayout>
                 </ScrollView>
                 <editor:ColorInspector Gradient="{Binding Gradient}" Margin="10" />
                 <ScrollView>

--- a/Playground/Playground/Features/Editor/GradientEditorPage.xaml.cs
+++ b/Playground/Playground/Features/Editor/GradientEditorPage.xaml.cs
@@ -1,11 +1,18 @@
-﻿using SkiaSharp;
+﻿using MagicGradients;
+using SkiaSharp;
 using SkiaSharp.Views.Forms;
+using System;
+using System.Threading.Tasks;
 using Xamarin.Forms;
+using VM = Playground.Features.Editor.GradientEditorViewModel;
 
 namespace Playground.Features.Editor
 {
     public partial class GradientEditorPage : ContentPage
     {
+        private readonly string MaskPath = $"{nameof(VM.Mask)}.{nameof(VM.Mask.Collection)}";
+        private readonly string UseLegacyShaderPath = $"{nameof(VM.Linear)}.{nameof(VM.Linear.UseLegacyShader)}";
+
         private SKSizeI _size;
         private SKPoint _prev;
         private long _touchId;
@@ -13,6 +20,7 @@ namespace Playground.Features.Editor
         public GradientEditorPage()
         {
             InitializeComponent();
+            AddSoftwareView();
         }
 
         private void SKCanvasView_OnTouch(object sender, SKTouchEventArgs e)
@@ -53,6 +61,71 @@ namespace Playground.Features.Editor
         private void SKCanvasView_OnPaintSurface(object sender, SKPaintSurfaceEventArgs e)
         {
             _size = e.Info.Size;
+        }
+
+        private void SKGLView_OnPaintSurface(object sender, SKPaintGLSurfaceEventArgs e)
+        {
+            _size = e.BackendRenderTarget.Size;
+        }
+
+        private async void SoftButton_OnClicked(object sender, EventArgs e)
+        {
+            if (RootLayout.Children[1] is GradientGLView current)
+            {
+                current.Touch -= SKCanvasView_OnTouch;
+                current.PaintSurface -= SKGLView_OnPaintSurface;
+                RootLayout.Children.RemoveAt(1);
+
+                await Task.Delay(200); // Visual feedback
+
+                AddSoftwareView();
+            }
+        }
+
+        private async void GpuButton_OnClicked(object sender, EventArgs e)
+        {
+            if (RootLayout.Children[1] is GradientView current)
+            {
+                current.Touch -= SKCanvasView_OnTouch;
+                current.PaintSurface -= SKCanvasView_OnPaintSurface;
+                RootLayout.Children.RemoveAt(1);
+
+                await Task.Delay(200); // Visual feedback
+
+                AddGpuView();
+            }
+        }
+
+        private void AddSoftwareView()
+        {
+            var view = new GradientView();
+            view.SetBinding(GradientView.GradientSourceProperty, nameof(VM.GradientSource));
+            view.SetBinding(GradientView.GradientSizeProperty, nameof(VM.GradientSize));
+            view.SetBinding(GradientView.GradientRepeatProperty, nameof(VM.GradientRepeat));
+            view.SetBinding(GradientView.EnableTouchEventsProperty, nameof(VM.IsDragEnabled));
+            view.SetBinding(GradientView.MaskProperty, MaskPath);
+            view.SetBinding(LinearGradient.UseLegacyShaderProperty, UseLegacyShaderPath);
+
+            view.Touch += SKCanvasView_OnTouch;
+            view.PaintSurface += SKCanvasView_OnPaintSurface;
+
+            RootLayout.Children.Insert(1, view);
+        }
+
+        private void AddGpuView()
+        {
+            var gpuView = new GradientGLView();
+            gpuView.SetBinding(GradientGLView.GradientSourceProperty, nameof(VM.GradientSource));
+            gpuView.SetBinding(GradientGLView.GradientSizeProperty, nameof(VM.GradientSize));
+            gpuView.SetBinding(GradientGLView.GradientRepeatProperty, nameof(VM.GradientRepeat));
+            gpuView.SetBinding(GradientGLView.EnableTouchEventsProperty, nameof(VM.IsDragEnabled));
+            gpuView.SetBinding(GradientGLView.MaskProperty, MaskPath);
+            gpuView.SetBinding(LinearGradient.UseLegacyShaderProperty, UseLegacyShaderPath);
+
+            gpuView.Touch += SKCanvasView_OnTouch;
+            gpuView.PaintSurface += SKGLView_OnPaintSurface;
+
+            RootLayout.Children.Insert(1, gpuView);
         }
     }
 }

--- a/Playground/Playground/Features/Masks/MasksPage.css
+++ b/Playground/Playground/Features/Masks/MasksPage.css
@@ -11,8 +11,8 @@
 
 .headerXamagonGlow {
     background: radial-gradient(circle at center center, rgb(216, 248, 247),rgb(253, 176, 22));
-    width: 130;
-    height: 130;
+    width: 120;
+    height: 120;
     margin: 20;
 }
 
@@ -26,9 +26,9 @@
 
 .goldStar {
     background: radial-gradient(circle at center center, rgb(233, 240, 92),rgb(236, 129, 32));
-    background-size: 100px, 100px;
+    background-size: 25%, 100%;
     background-repeat: repeat-x;
-    width: 300;
+    width: 350;
     height: 100;
 }
 

--- a/Playground/Playground/Features/Masks/MasksPage.xaml
+++ b/Playground/Playground/Features/Masks/MasksPage.xaml
@@ -37,9 +37,9 @@
                 </Grid>
                 <Grid Grid.Row="1">
                     <magic:GradientView StyleClass="headerBackground" />
-                    <magic:GradientView StyleClass="headerXamagonGlow" IgnorePixelScaling="True" HorizontalOptions="Center" VerticalOptions="Center">
+                    <magic:GradientView StyleClass="headerXamagonGlow" HorizontalOptions="Center" VerticalOptions="Center">
                         <magic:GradientView.Mask>
-                            <masks:EllipseMask Size="100,100" FillMode="AspectFit" />
+                            <masks:EllipseMask FillMode="AspectFit" />
                         </magic:GradientView.Mask>
                     </magic:GradientView>
                     <magic:GradientView StyleClass="headerXamagon" HorizontalOptions="Center" VerticalOptions="Center">
@@ -51,7 +51,6 @@
                     </magic:GradientView>
                 </Grid>
                 <magic:GradientView StyleClass="goldStar" 
-                                    IgnorePixelScaling="True"
                                     HorizontalOptions="Center" 
                                     VerticalOptions="Center"
                                     Grid.Row="2">


### PR DESCRIPTION
Adds `GradientGLView` alternative for GPU rendering. Improves performance of complex gradients, especially radials on UWP.

Usage of `GradientGLView` is optional at the moment if standard `GradientView` is lacking performance. 

There is a SkiaSharp bug on UWP which may cause crashes in some scenarios:
https://github.com/mono/SkiaSharp/issues/1573