### PR TITLE
Add Shell Scripts for MacOS

### DIFF
--- a/Scripts/PublishNuGetsLocal.sh
+++ b/Scripts/PublishNuGetsLocal.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+GREEN=`tput setaf 2`
+
+NuGetPath="../MagicGradients/bin/**/Release/*.nupkg"
+PackagesFolder="~/Packages"
+
+echo "${GREEN}Remove all nupkg's"
+rm $NuGetPath
+
+echo "Build NuGet & Copy for $1" 
+nuget pack $1 -Build -Properties Configuration=Release -OutputDirectory ~/Packages
+
+echo "Completed."

--- a/Scripts/UpdateNuGetVersion.ps1
+++ b/Scripts/UpdateNuGetVersion.ps1
@@ -29,6 +29,7 @@ Function Update-AllNuGetVersions{
         )
         
         Update-NuGetVersion $Version '..\MagicGradients\MagicGradients.csproj';
+        #Update-NuGetVersion $Version '..\MagicGradients.Toolkit\MagicGradients.Toolkit.csproj';
 }
 
 Update-AllNuGetVersions

--- a/Scripts/UpdateNuGetVersion.sh
+++ b/Scripts/UpdateNuGetVersion.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+GREEN=`tput setaf 2`
+
+Version=$1
+MagicGradients="../MagicGradients/MagicGradients.csproj"
+MagicGradientsToolkit="../MagicGradients.Toolkit/MagicGradients.Toolkit.csproj"
+
+echo "${GREEN}Set new $Version version for $MagicGradients"
+sed "s|<Version>.*|<Version>$Version<\/Version>|" $MagicGradients | tee $MagicGradients
+
+#echo "Set new $Version version for $MagicGradientsToolkit"
+#sed "s|<Version>.*|<Version>$Version<\/Version>|" $MagicGradientsToolkit | tee $MagicGradientsToolkit
+


### PR DESCRIPTION
Under this PR I just add similar to PowerShell Scripts for MacOS users 😉

For `PublishNuGetsLocal.sh` script we have a small difference comparing to `PublishNuGetsLocal.ps1`

```sh
> ./PublishNuGetsLocal.sh ../MagicGradients/MagicGradients.csproj
```
We need to specify `csproj` file instead of `sln` because `msbuild` on MacOS does not have a `pack` option and we use `nuget pack` command in this script

Second Script has the same usage as his PowerShell copy
```sh
> ./UpdateNuGetVersion.sh 1.4.0
```