### PR TITLE
Fix Font Icons on Home page

### DIFF
--- a/Playground/Playground/Features/Home/HomePage.css
+++ b/Playground/Playground/Features/Home/HomePage.css
@@ -23,7 +23,7 @@ MagicButton {
     background: radial-gradient(circle at top center, rgb(176, 142, 252),rgb(60, 0, 159));
 }
 
-MagicButton Label {
+MagicButton .MenuText {
     color: white;
     font-size: 18;
 }

--- a/Playground/Playground/Features/Home/HomePage.xaml
+++ b/Playground/Playground/Features/Home/HomePage.xaml
@@ -11,6 +11,10 @@
              vm:ViewModelLocator.AutoWireViewModel="true">
     <ContentPage.Resources>
         <StyleSheet Source="/Features/Home/HomePage.css" />
+        <Style Class="MenuIcon" TargetType="Label"  BasedOn="{StaticResource FontLabel}">
+            <Setter Property="FontSize" Value="50" />
+            <Setter Property="TextColor" Value="White" />
+        </Style>
     </ContentPage.Resources>
     <Grid RowDefinitions="150,*">
         <magic:GradientView VerticalOptions="Fill" StyleId="banner" />
@@ -27,23 +31,20 @@
                 </controls:MenuSection>
                 <toolkit:MagicButton Command="{Binding LinearCommand}" StyleClass="threeColumn">
                     <StackLayout Padding="10" HorizontalOptions="Center">
-                        <Image Source="{ic:IcoMoon {x:Static ic:IcoMoonGlyph.Gradient}, Color=White, Size=50}" 
-                               Margin="{OnPlatform UWP='10,0,0,0'}" />
-                        <Label Text="Linear" HorizontalOptions="Center" />
+                        <Label Text="{x:Static ic:IcoMoonGlyph.Gradient}" StyleClass="MenuIcon" />
+                        <Label Text="Linear" HorizontalOptions="Center" StyleClass="MenuText" />
                     </StackLayout>
                 </toolkit:MagicButton>
                 <toolkit:MagicButton Command="{Binding RadialCommand}" StyleClass="threeColumn">
                     <StackLayout Padding="10" HorizontalOptions="Center">
-                        <Image Source="{ic:IcoMoon {x:Static ic:IcoMoonGlyph.Radial}, Color=White, Size=50}" 
-                               Margin="{OnPlatform UWP='10,0,0,0'}" />
-                        <Label Text="Radial" HorizontalOptions="Center" />
+                        <Label Text="{x:Static ic:IcoMoonGlyph.Radial}" StyleClass="MenuIcon" />
+                        <Label Text="Radial" HorizontalOptions="Center" StyleClass="MenuText" />
                     </StackLayout>
                 </toolkit:MagicButton>
                 <toolkit:MagicButton Command="{Binding CssCommand}" StyleClass="threeColumn">
                     <StackLayout Padding="10" HorizontalOptions="Center">
-                        <Image Source="{ic:IcoMoon {x:Static ic:IcoMoonGlyph.Palette}, Color=White, Size=50}" 
-                               Margin="{OnPlatform UWP='10,0,0,0'}"/>
-                        <Label Text="CSS" HorizontalOptions="Center" />
+                        <Label Text="{x:Static ic:IcoMoonGlyph.Palette}" StyleClass="MenuIcon" />
+                        <Label Text="CSS" HorizontalOptions="Center" StyleClass="MenuText" />
                     </StackLayout>
                 </toolkit:MagicButton>
                 <controls:MenuSection>
@@ -51,23 +52,20 @@
                 </controls:MenuSection>
                 <toolkit:MagicButton Command="{Binding GalleryCommand}" StyleClass="threeColumn">
                     <StackLayout Padding="10" HorizontalOptions="Center">
-                        <Image Source="{ic:IcoMoon {x:Static ic:IcoMoonGlyph.Gallery}, Color=White, Size=50}" 
-                               Margin="{OnPlatform UWP='10,0,0,0'}" />
-                        <Label Text="Gallery" HorizontalOptions="Center" />
+                        <Label Text="{x:Static ic:IcoMoonGlyph.Gallery}" StyleClass="MenuIcon" />
+                        <Label Text="Gallery" HorizontalOptions="Center" StyleClass="MenuText" />
                     </StackLayout>
                 </toolkit:MagicButton>
                 <toolkit:MagicButton Command="{Binding AnimationsCommand}" StyleClass="threeColumn">
                     <StackLayout Padding="10" HorizontalOptions="Center">
-                        <Image Source="{ic:IcoMoon {x:Static ic:IcoMoonGlyph.Bolt}, Color=White, Size=50}" 
-                               Margin="{OnPlatform UWP='10,0,0,0'}" />
-                        <Label Text="Animations" HorizontalOptions="Center" />
+                        <Label Text="{x:Static ic:IcoMoonGlyph.Bolt}" StyleClass="MenuIcon" />
+                        <Label Text="Animations" HorizontalOptions="Center" StyleClass="MenuText" />
                     </StackLayout>
                 </toolkit:MagicButton>
                 <toolkit:MagicButton Command="{Binding MasksCommand}" StyleClass="threeColumn">
                     <StackLayout Padding="10" HorizontalOptions="Center">
-                        <Image Source="{ic:IcoMoon {x:Static ic:IcoMoonGlyph.Mask}, Color=White, Size=50}" 
-                               Margin="{OnPlatform UWP='10,0,0,0'}" />
-                        <Label Text="Masks" HorizontalOptions="Center" />
+                        <Label Text="{x:Static ic:IcoMoonGlyph.Mask}" StyleClass="MenuIcon" />
+                        <Label Text="Masks" HorizontalOptions="Center" StyleClass="MenuText" />
                     </StackLayout>
                 </toolkit:MagicButton>
             </FlexLayout>


### PR DESCRIPTION
Font icon is randomly broken when used as `FontImageSource` extension. Using pure `FontImageSource` or a `Label` seems to not have this issue. This PR is another attempt to fix broken icons - home screen without `FontImageSource` extension can be compared to other broken pages.