### PR TITLE
Roll Back Init Safe Area for iOS

### DIFF
--- a/Playground/Playground/Features/Home/HomePage.xaml.cs
+++ b/Playground/Playground/Features/Home/HomePage.xaml.cs
@@ -9,6 +9,15 @@ namespace Playground.Features.Home
         public HomePage()
         {
             InitializeComponent();
+            PropertyChanged += ContentPageBase_PropertyChanged;
+        }
+
+        private void ContentPageBase_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == "SafeAreaInsets")
+            {
+                this.InitSafeAreaInsets();
+            }
         }
     }
 }


### PR DESCRIPTION
Problem: SafeArea was removed from the home page, but it has an impact on Gradient Editor Page, where it allow to press bottom buttons